### PR TITLE
Added reference to CAF docs, for longer details

### DIFF
--- a/landingzones/landingzone_caf_foundations/readme.md
+++ b/landingzones/landingzone_caf_foundations/readme.md
@@ -5,6 +5,8 @@ The foundation landing zone sets the basics of operations, accounting and auditi
 ## Foundations architecture diagram
 ![Foundations blueprint overview](../../_pictures/caf_foundations/foundations_overall.png)
 
+For an explanation on the purposes of the components in this foundational landing zone, please have a look at this specific Cloud Adoption Framework documentation: [Use Terraform to build your landing zones](https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/terraform-landing-zone).
+
 ## Getting Started
 To deploy a landingzone, refer to the setup instructions here: https://github.com/aztfmod/landingzones
 


### PR DESCRIPTION
Following 'getting started' walk-throughs of the rover, I deployed the foundational landing zone. Naturally, I'll like to see what it does. Following the source, I arrive at this part of the repository, but that's where the trail ends for me.

Having a link to the CAF documentation will allow readers that are 'looking through the stack' to learn about the Terraform approach to CAF a follow on trail to get more understanding on what they are getting into, albeit a bottom-up trail back to those high-level docs.