### PR TITLE
Add multi-region diagnostic support

### DIFF
--- a/landingzones/landingzone_networking/firewall.tf
+++ b/landingzones/landingzone_networking/firewall.tf
@@ -13,8 +13,8 @@ module "az_firewall_ip" {
   resource_group_name        = azurerm_resource_group.rg[each.value.resource_group_key].name
   ip_addr                    = each.value.firewall_ip_addr_config
   tags                       = local.tags
-  diagnostics_map            = local.caf_foundations_accounting.diagnostics_map
-  log_analytics_workspace_id = local.caf_foundations_accounting.log_analytics_workspace.id
+  diagnostics_map            = local.caf_foundations_accounting[each.value.location].diagnostics_map
+  log_analytics_workspace_id = local.caf_foundations_accounting[each.value.location].log_analytics_workspace.id
   diagnostics_settings       = each.value.firewall_ip_addr_config.diagnostics
 }
 
@@ -32,8 +32,8 @@ module "az_firewall" {
   public_ip_id         = module.az_firewall_ip[each.key].id
   location             = each.value.location
   tags                 = local.tags
-  diagnostics_map      = local.caf_foundations_accounting.diagnostics_map
-  la_workspace_id      = local.caf_foundations_accounting.log_analytics_workspace.id
+  diagnostics_map      = local.caf_foundations_accounting[each.value.location].diagnostics_map
+  la_workspace_id      = local.caf_foundations_accounting[each.value.location].log_analytics_workspace.id
   diagnostics_settings = each.value.az_fw_config.diagnostics
 }
 

--- a/landingzones/landingzone_networking/vnet.tf
+++ b/landingzones/landingzone_networking/vnet.tf
@@ -11,8 +11,8 @@ module "vnets" {
   location                = lookup(each.value, "location", azurerm_resource_group.rg[each.value.resource_group_key].location)
   networking_object       = each.value
   tags                    = local.tags
-  diagnostics_map         = local.caf_foundations_accounting.diagnostics_map
-  log_analytics_workspace = local.caf_foundations_accounting.log_analytics_workspace
+  diagnostics_map         = local.caf_foundations_accounting[each.value.location].diagnostics_map
+  log_analytics_workspace = local.caf_foundations_accounting[each.value.location].log_analytics_workspace
   diagnostics_settings    = lookup(each.value, "diagnostics", var.diagnostics.vnet)
   ddos_id                 = ""
 }


### PR DESCRIPTION
Breaking change - require to teardown the caf foundations and re-deploy.
Configuration files of caf-fondations must be updated to support the multi-region