### PR TITLE
[bugfix] Fixed passing in the list of supported services

### DIFF
--- a/landingzones/landingzone_caf_foundations/blueprint_foundations_governance/policies/builtin/allowed_resource_type.tf
+++ b/landingzones/landingzone_caf_foundations/blueprint_foundations_governance/policies/builtin/allowed_resource_type.tf
@@ -1,6 +1,10 @@
 #Definition ID: /providers/Microsoft.Authorization/policyDefinitions/a08ec900-254a-4555-9bf5-e42af04b5c5c
 #Name: Allowed resource types
 
+locals {
+  supported_svc = "${jsonencode(var.policies_matrix.list_of_supported_svc)}"
+}
+
 resource "azurerm_policy_assignment" "res_type" {
   count                = var.policies_matrix.restrict_supported_svc ? 1 : 0
   name                 = "res_svc"
@@ -12,10 +16,8 @@ resource "azurerm_policy_assignment" "res_type" {
   parameters = <<PARAMETERS
     {
       "listOfResourceTypesAllowed": {
-        {
-                "value" : "${var.policies_matrix.list_of_supported_svc}"
-              }
+        "value" : ${local.supported_svc}
     }
-    }
+}
 PARAMETERS
 }


### PR DESCRIPTION
Added the missing encoding.

With the fix, the plan will succeed and allow apply:
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:
```
  # module.blueprint_foundations_governance.module.builtin_policies.azurerm_policy_assignment.res_type[0] will be created
  + resource "azurerm_policy_assignment" "res_type" {
      + description          = "Policy Assignment with Terraform"
      + display_name         = "TF Restrict Deployment of specified Azure Resources"
      + enforcement_mode     = true
      + id                   = (known after apply)
      + name                 = "res_svc"
      + parameters           = jsonencode(
            {
              + listOfResourceTypesAllowed = {
                  + value = [
                      + "Microsoft.Network/publicIPAddresses",
                      + "Microsoft.Compute/disks",
                    ]
                }
            }
        )
      + policy_definition_id = "/providers/Microsoft.Authorization/policyDefinitions/a08ec900-254a-4555-9bf5-e42af04b5c5c"
      + scope                = "/subscriptions/1ae83116-7c3c-446d-8015-9ae244c26257"

      + identity {
          + principal_id = (known after apply)
          + tenant_id    = (known after apply)
          + type         = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Fixes: https://github.com/Azure/caf-terraform-landingzones/issues/61