### PR TITLE
Initial support for TFC bootstrap as add-on

### DIFF
--- a/landingzones/caf_launchpad/add-ons/terraform_cloud/example/tfc.tfvars
+++ b/landingzones/caf_launchpad/add-ons/terraform_cloud/example/tfc.tfvars
@@ -1,0 +1,25 @@
+landingzone = {
+  backend_type = "remote"
+  level        = "level0"
+  key          = "launchpad"
+}
+
+# Create the TFC organization
+tfe_organizations = {
+  caf_lz = {
+    name  = "caf-landingzones-test3"
+    email = "admin@your-company.com"
+
+  }
+}
+
+# Create the required TFE workspaces
+tfe_workspaces = {
+  caf_launchpad = {
+    # specifies the object key for the organization where to create the workspace
+    organization_key = "caf_lz"
+    name             = "caf_launchpad"
+    # path to place the backend file for the corresponding landing zone
+    backend_file = "/backend.hcl"
+  }
+}

--- a/landingzones/caf_launchpad/add-ons/terraform_cloud/main.tf
+++ b/landingzones/caf_launchpad/add-ons/terraform_cloud/main.tf
@@ -1,0 +1,51 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.32.0"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = "~> 1.0.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.2.1"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1.0"
+    }
+    external = {
+      source  = "hashicorp/external"
+      version = "~> 1.2.0"
+    }
+    tfe = {
+      source  = "hashicorp/tfe"
+      version = "~> 0.22.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = true
+    }
+  }
+}
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  tfstates = merge(
+    map(var.landingzone.backend_type,
+      map(
+        "level", var.landingzone.level,
+        "tenant_id", data.azurerm_client_config.current.tenant_id,
+        "subscription_id", data.azurerm_client_config.current.subscription_id
+      )
+    )
+  )
+}

--- a/landingzones/caf_launchpad/add-ons/terraform_cloud/readme.md
+++ b/landingzones/caf_launchpad/add-ons/terraform_cloud/readme.md
@@ -1,0 +1,44 @@
+# Add-on to deploy a Terraform Cloud / Terraform Enterprise configuration for Azure CAF landing zones
+
+Supported scenario in this release:
+
+1. Create the TFE/TFC environment (organization, variables, workspaces)
+
+Future scenarios:
+
+1. Use TFE/TFC as remote backend (local execution, backend in TFC)
+2. Deploy Terraform Enterprise Server and remote agents
+3. Use TFE/TFC in online mode (execution in TFE with remote agents)
+
+## Authenticating to Terraform Cloud
+
+First step is to authenticate to TFC using the following commands:
+
+```bash
+terraform login
+export TERRAFORM_CONFIG="$HOME/.terraform.d/credentials.tfrc.json"
+```
+
+## Creating the TFC environment
+
+This will setup TFC organization, workspaces and variables to host landing zones.
+
+```bash
+# Deploy
+rover -lz /tf/caf/landingzones/caf_launchpad/add-ons/tfc/ \
+-var-folder /tf/caf/landingzones/caf_launchpad/add-ons/tfc/example/ \
+-a plan -launchpad
+
+or
+cd /tf/caf/landingzones/caf_launchpad/add-ons/terraform_cloud/
+terraform init
+terraform plan \
+-var-file /tf/caf/landingzones/caf_launchpad/add-ons/terraform_cloud/example/tfc.tfvars
+```
+
+Once ready, you can create your configuration:
+
+```bash
+terraform apply \
+-var-file /tf/caf/landingzones/caf_launchpad/add-ons/terraform_cloud/example/tfc.tfvars
+```

--- a/landingzones/caf_launchpad/add-ons/terraform_cloud/terraform_cloud.tf
+++ b/landingzones/caf_launchpad/add-ons/terraform_cloud/terraform_cloud.tf
@@ -1,0 +1,83 @@
+
+resource "tfe_organization" "tfe_org" {
+  for_each = try(var.tfe_organizations, {})
+
+  name                     = each.value.name
+  email                    = each.value.email
+  session_timeout_minutes  = try(each.value.session_timeout_minutes, 20160)
+  session_remember_minutes = try(each.value.session_remember_minutes, 20160)
+  collaborator_auth_policy = try(each.value.collaborator_auth_policy, "password")
+  owners_team_saml_role_id = try(each.value.owners_team_saml_role_id, null)
+}
+
+resource "tfe_workspace" "tfe_wks" {
+  for_each = try(var.tfe_workspaces, {})
+
+  name                  = each.value.name
+  organization          = tfe_organization.tfe_org[each.value.organization_key].name
+  auto_apply            = try(each.value.auto_apply, false)
+  file_triggers_enabled = try(each.value.file_triggers_enabled, true)
+  operations            = try(each.value.operations, true)
+  queue_all_runs        = try(each.value.queue_all_runs, true)
+  speculative_enabled   = try(each.value.speculative_enabled, true)
+  ssh_key_id            = try(each.value.ssh_key_id, null)
+  terraform_version     = try(each.value.terraform_version, null)
+  trigger_prefixes      = try(each.value.trigger_prefixes, null)
+  working_directory     = try(each.value.working_directory, null)
+
+  dynamic "vcs_repo" {
+    for_each = lookup(each.value, "vcs_repo", null) == null ? [] : [1]
+
+    content {
+      identifier         = each.value.vcs_repo.identifier
+      branch             = try(each.value.vcs_repo.branch, null)
+      ingress_submodules = try(each.value.vcs_repo.ingress_submodules, false)
+      oauth_token_id     = each.value.vcs_repo.oauth_token_id
+    }
+  }
+}
+
+resource "tfe_variable" "variable" {
+  for_each = try(var.tfe_variables, {})
+
+  key          = each.value.key_name
+  value        = each.value.value
+  category     = each.value.category
+  workspace_id = tfe_workspace.tfe_wks[each.value.workspace_key].id
+  description  = each.value.description
+  hcl          = try(each.value.hcl, false)
+  sensitive    = try(each.value.sensitive, false)
+}
+
+resource "null_resource" "backend_file" {
+  depends_on = [tfe_workspace.tfe_wks]
+  for_each   = try(var.tfe_workspaces, {})
+
+  provisioner "local-exec" {
+    working_dir = "./"
+    command     = "echo workspaces '{' name = \\\"${each.value.name}\\\" '}' >> ${path.cwd}${each.value.backend_file}"
+  }
+  provisioner "local-exec" {
+    working_dir = "./"
+    command     = "echo hostname = \\\"app.terraform.io\\\" >> ${path.cwd}${each.value.backend_file}"
+  }
+  provisioner "local-exec" {
+    working_dir = "./"
+    command     = "echo organization = \\\"${tfe_organization.tfe_org[each.value.organization_key].name}\\\" >> ${path.cwd}${each.value.backend_file}"
+  }
+}
+
+resource "null_resource" "backend_file_destroy" {
+  depends_on = [tfe_workspace.tfe_wks]
+  for_each   = try(var.tfe_workspaces, {})
+
+  triggers = {
+    backend_file = lookup(each.value, "backend_file")
+  }
+
+  provisioner "local-exec" {
+    command     = format("rm %s%s", path.cwd,  self.triggers.backend_file)
+    when        = destroy
+    on_failure  = fail
+  }
+}

--- a/landingzones/caf_launchpad/add-ons/terraform_cloud/variables.tf
+++ b/landingzones/caf_launchpad/add-ons/terraform_cloud/variables.tf
@@ -1,0 +1,85 @@
+# Map of the remote data state for lower level
+variable lower_storage_account_name {
+  default = {}
+}
+variable lower_container_name {
+  default = {}
+}
+variable lower_resource_group_name {
+  default = {}
+}
+
+variable tfstate_storage_account_name {
+  default = {}
+}
+variable tfstate_container_name {
+  default = {}
+}
+variable tfstate_key {
+  default = {}
+}
+variable tfstate_resource_group_name {
+  default = {}
+}
+
+variable global_settings {
+  default = {}
+}
+variable tenant_id {
+  default = {}
+}
+variable landingzone {
+  default = {}
+}
+
+variable rover_version {
+  default = null
+}
+
+variable logged_user_objectId {
+  default = null
+}
+variable logged_aad_app_objectId {
+  default = null
+}
+variable tags {
+  default = null
+}
+variable keyvaults {
+  default = {}
+}
+variable keyvault_access_policies {
+  default = {}
+}
+variable role_mapping {
+  default = {}
+}
+variable secrets_from_keys {
+  default = {}
+}
+variable custom_role_definitions {
+  default = {}
+}
+variable azuread_apps {
+  default = {}
+}
+
+variable tfe_organizations {
+  default = {}
+}
+
+variable tfe_workspaces {
+  default = {}
+}
+
+variable tfe_variables {
+  default = {}
+}
+
+variable tfe_servers {
+  default = {}
+}
+
+variable tfe_agents {
+  default = {}
+}


### PR DESCRIPTION
Supported scenario in this release:

- [X] 1. Create the TFE/TFC environment (organization, variables, workspaces)

Future scenarios:

- [ ] 1. Use TFE/TFC as remote backend (local execution, backend in TFC)
- [ ] 2. Deploy Terraform Enterprise Server and remote agents
- [ ] 3. Use TFE/TFC in online mode (execution in TFE with remote agents)