### PR TITLE
add RG and VM in output

### DIFF
--- a/landingzones/caf_solutions/locals.remote_tfstates.tf
+++ b/landingzones/caf_solutions/locals.remote_tfstates.tf
@@ -137,6 +137,9 @@ locals {
     synapse_workspaces = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.synapse_workspaces[key], {}))
     }
+    virtual_machines = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.virtual_machines[key], {}))
+    }
     vnets = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.vnets[key], {}))
     }
@@ -153,6 +156,8 @@ locals {
     mssql_servers                    = merge(local.remote.mssql_servers, tomap({ (var.landingzone.key) = module.caf.mssql_servers }))
     private_dns                      = merge(local.remote.private_dns, tomap({ (var.landingzone.key) = module.caf.private_dns }))
     public_ip_addresses              = merge(local.remote.public_ip_addresses, tomap({ (var.landingzone.key) = module.caf.public_ip_addresses }))
+    resource_groups                  = merge(local.remote.resource_groups, tomap({ (var.landingzone.key) = module.caf.resource_groups }))
+    virtual_machines                 = merge(local.remote.virtual_machines, tomap({ (var.landingzone.key) = module.caf.virtual_machines }))
     vnets                            = merge(local.remote.vnets, tomap({ (var.landingzone.key) = module.caf.vnets }))
   }
 }

--- a/landingzones/caf_solutions/output.tf
+++ b/landingzones/caf_solutions/output.tf
@@ -118,3 +118,6 @@ output resource_groups {
   value   = local.combined.resource_groups
 }
 
+output vnets {
+  value   = local.combined.vnets
+}

--- a/landingzones/caf_solutions/output.tf
+++ b/landingzones/caf_solutions/output.tf
@@ -90,7 +90,7 @@ output aks_clusters {
 }
 
 output virtual_machines {
-  value     = module.caf.virtual_machines
+  value     = local.combined.virtual_machines
   sensitive = false
 }
 
@@ -110,5 +110,11 @@ output synapse_workspaces {
   sensitive = true
 }
 
+output public_ip_addresses {
+  value   = local.combined.public_ip_addresses
+}
 
+output resource_groups {
+  value   = local.combined.resource_groups
+}
 


### PR DESCRIPTION
# [Add resource_groups and virtual_machines in the output](https://github.com/Azure/caf-terraform-landingzones/issues/150)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
Adding resource_groups and virtual_machines in the output to be reused from other LZ

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
