### PR TITLE
Add sovereign cloud endpoints and suffix environment variables (part 2)

### DIFF
--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -10,6 +10,7 @@ module "solution" {
   azuread_groups                        = var.azuread_groups
   azuread_roles                         = var.azuread_roles
   azuread_users                         = var.azuread_users
+  cloud                                 = local.cloud
   compute                               = local.compute
   current_landingzone_key               = var.landingzone.key
   custom_role_definitions               = var.custom_role_definitions

--- a/caf_solution/local.cloud.tf
+++ b/caf_solution/local.cloud.tf
@@ -1,0 +1,40 @@
+locals {
+  cloud = merge(
+    var.cloud,
+    {
+      acrLoginServerEndpoint                      = var.acrLoginServerEndpoint
+      attestationEndpoint                         = var.attestationEndpoint
+      azureDatalakeAnalyticsCatalogAndJobEndpoint = var.azureDatalakeAnalyticsCatalogAndJobEndpoint
+      azureDatalakeStoreFileSystemEndpoint        = var.azureDatalakeStoreFileSystemEndpoint
+      keyvaultDns                                 = var.keyvaultDns
+      mariadbServerEndpoint                       = var.mariadbServerEndpoint
+      mhsmDns                                     = var.mhsmDns
+      mysqlServerEndpoint                         = var.mysqlServerEndpoint
+      postgresqlServerEndpoint                    = var.postgresqlServerEndpoint
+      sqlServerHostname                           = var.sqlServerHostname
+      storageEndpoint                             = var.storageEndpoint
+      storageSyncEndpoint                         = var.storageSyncEndpoint
+      synapseAnalyticsEndpoint                    = var.synapseAnalyticsEndpoint
+      activeDirectory                             = var.activeDirectory
+      activeDirectoryDataLakeResourceId           = var.activeDirectoryDataLakeResourceId
+      activeDirectoryGraphResourceId              = var.activeDirectoryGraphResourceId
+      activeDirectoryResourceId                   = var.activeDirectoryResourceId
+      appInsightsResourceId                       = var.appInsightsResourceId
+      appInsightsTelemetryChannelResourceId       = var.appInsightsTelemetryChannelResourceId
+      attestationResourceId                       = var.attestationResourceId
+      azmirrorStorageAccountResourceId            = var.azmirrorStorageAccountResourceId
+      batchResourceId                             = var.batchResourceId
+      gallery                                     = var.gallery
+      logAnalyticsResourceId                      = var.logAnalyticsResourceId
+      management                                  = var.management
+      mediaResourceId                             = var.mediaResourceId
+      microsoftGraphResourceId                    = var.microsoftGraphResourceId
+      ossrdbmsResourceId                          = var.ossrdbmsResourceId
+      portal                                      = var.portal
+      resourceManager                             = var.resourceManager
+      sqlManagement                               = var.sqlManagement
+      synapseAnalyticsResourceId                  = var.synapseAnalyticsResourceId
+      vmImageAliasDoc                             = var.vmImageAliasDoc
+    }
+  )
+}

--- a/caf_solution/variables.cloud.tf
+++ b/caf_solution/variables.cloud.tf
@@ -1,0 +1,107 @@
+variable "cloud" {
+  description = "Cloud configuration objects"
+  default     = {}
+}
+
+# Azure Public Cloud defaults for non-Rover use 
+# Rover updates values based on active cloud
+
+variable "acrLoginServerEndpoint" {
+  default = ".azurecr.io"
+}
+variable "attestationEndpoint" {
+  default = ".attest.azure.net"
+}
+variable "azureDatalakeAnalyticsCatalogAndJobEndpoint" {
+  default = "azuredatalakeanalytics.net"
+}
+variable "azureDatalakeStoreFileSystemEndpoint" {
+  default = "azuredatalakestore.net"
+}
+variable "keyvaultDns" {
+  default = ".vault.azure.net"
+}
+variable "mariadbServerEndpoint" {
+  default = ".mariadb.database.azure.com"
+}
+variable "mhsmDns" {
+  default = ".managedhsm.azure.net"
+}
+variable "mysqlServerEndpoint" {
+  default = ".mysql.database.azure.com"
+}
+variable "postgresqlServerEndpoint" {
+  default = ".postgres.database.azure.com"
+}
+variable "sqlServerHostname" {
+  default = ".database.windows.net"
+}
+variable "storageEndpoint" {
+  default = "core.windows.net"
+}
+variable "storageSyncEndpoint" {
+  default = "afs.azure.net"
+}
+variable "synapseAnalyticsEndpoint" {
+  default = ".dev.azuresynapse.net"
+}
+variable "activeDirectory" {
+  default = "https://login.microsoftonline.com"
+}
+variable "activeDirectoryDataLakeResourceId" {
+  default = "https://datalake.azure.net/"
+}
+variable "activeDirectoryGraphResourceId" {
+  default = "https://graph.windows.net/"
+}
+variable "activeDirectoryResourceId" {
+  default = "https://management.core.windows.net/"
+}
+variable "appInsightsResourceId" {
+  default = "https://api.applicationinsights.io"
+}
+variable "appInsightsTelemetryChannelResourceId" {
+  default = "https://dc.applicationinsights.azure.com/v2/track"
+}
+variable "attestationResourceId" {
+  default = "https://attest.azure.net"
+}
+variable "azmirrorStorageAccountResourceId" {
+  default = "null"
+}
+variable "batchResourceId" {
+  default = "https://batch.core.windows.net/"
+}
+variable "gallery" {
+  default = "https://gallery.azure.com/"
+}
+variable "logAnalyticsResourceId" {
+  default = "https://api.loganalytics.io"
+}
+variable "management" {
+  default = "https://management.core.windows.net/"
+}
+variable "mediaResourceId" {
+  default = "https://rest.media.azure.net"
+}
+variable "microsoftGraphResourceId" {
+  default = "https://graph.microsoft.com/"
+}
+variable "ossrdbmsResourceId" {
+  default = "https://ossrdbms-aad.database.windows.net"
+}
+variable "portal" {
+  default = "https://portal.azure.com"
+}
+variable "resourceManager" {
+  default = "https://management.azure.com/"
+}
+variable "sqlManagement" {
+  default = "https://management.core.windows.net:8443/"
+}
+variable "synapseAnalyticsResourceId" {
+  default = "https://dev.azuresynapse.net"
+}
+variable "vmImageAliasDoc" {
+  default = "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-compute/quickstart-templates/aliases.json"
+}


### PR DESCRIPTION
# [Issue-183](https://github.com/Azure/caf-terraform-landingzones/issues/183)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ NA] I have updated the documentation accordingly.
- [ NA] I have added tests to cover my changes.
- [Pending] All new and existing tests passed.
- [x ] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR resolves part one of the bug issue. See issue for other parts.

Added complex cloud variable to store endpoints and suffixes from the logged in cloud
- Retrieve az cloud show endpoints and suffixes 
- Convert to variables to be passed to the modules
- Added Azure Public Cloud default values in the case the code is run without Rover
     - Can change to null defaults but opted for greater modularity.

closes #183 

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Use Azure update, Login to AzureUSGovernment and deploy a MSSQL db with db_permissions to see appropriate cloud URI in use.
