### PR TITLE
update aks add-on for aks cluster remote object

### DIFF
--- a/caf_solution/add-ons/aks_applications/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/aks_applications/locals.remote_tfstates.tf
@@ -36,7 +36,7 @@ locals {
 
   remote = {
     aks_clusters = {
-      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.aks_clusters[key], {}))
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].aks_clusters, {}))
     }
   }
 


### PR DESCRIPTION
# [189](https://github.com/Azure/caf-terraform-landingzones/issues/189)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This change updates the aks_applications add-on in caf_solution to pull aks cluster information using the new caf_solution object model.

## Does this introduce a breaking change

- [ ] YES
- [x] NO


## Testing

Create a demo or sandpit environment from the starter repo. After deploying aks on level3, deploy argo cd on level4 and it should correctly deploy the argo helm chart.
