### PR TITLE
Revert "Add vhub route tables as a remote object"

### DIFF
--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -1,10 +1,9 @@
 module "solution" {
-  # source  = "aztfmod/caf/azurerm"
-  # version = "~>5.3.2"
+  source  = "aztfmod/caf/azurerm"
+  version = "~>5.3.2"
 
-  source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=master"
+  # source = "git::https://github.com/aztfmod/terraform-azurerm-caf.git?ref=master"
 
-  # source = "../../aztfmod"
 
   azuread_api_permissions               = var.azuread_api_permissions
   azuread_apps                          = var.azuread_apps

--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -142,7 +142,7 @@ locals {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].synapse_workspaces, {}))
     }
     virtual_hub_route_tables = {
-      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_hub_route_table, {}))
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_hub_route_tables, {}))
     }
     virtual_wans = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_wans, {}))


### PR DESCRIPTION
Reverts Azure/caf-terraform-landingzones#188