### PR TITLE
add variable object for storage account queues

### DIFF
--- a/caf_solution/local.storage.tf
+++ b/caf_solution/local.storage.tf
@@ -2,8 +2,9 @@ locals {
   storage = merge(
     var.storage,
     {
-      netapp_accounts       = var.netapp_accounts
-      storage_account_blobs = var.storage_account_blobs
+      netapp_accounts        = var.netapp_accounts
+      storage_account_blobs  = var.storage_account_blobs
+      storage_account_queues = var.storage_account_queues
     }
   )
 }

--- a/caf_solution/variables.storage.tf
+++ b/caf_solution/variables.storage.tf
@@ -11,3 +11,6 @@ variable "storage_account_blobs" {
 variable "storage_accounts" {
   default = {}
 }
+variable "storage_account_queues" {
+  default = {}
+}


### PR DESCRIPTION
# [217](https://github.com/Azure/caf-terraform-landingzones/issues/217)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [ x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

This PR adds a variable and output for Azure Storage Queues so that we may capture any relevant outputs that need to be used downstream, for example, the queue name and location. 

## Does this introduce a breaking change

- [ ] YES
- [x] NO
