### PR TITLE
Update aks-secure-baseline add-ons (V1 and V2) to support aks cluster with user assigned identity

### DIFF
--- a/caf_solution/add-ons/aks-secure-baseline/aks-pod-identity-assignment.tf
+++ b/caf_solution/add-ons/aks-secure-baseline/aks-pod-identity-assignment.tf
@@ -30,11 +30,10 @@ resource "azurerm_role_assignment" "kubelet_vnet_networkcontrib" {
 
   scope                = local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].subnets[each.value].id
   role_definition_name = "Network Contributor"
-  principal_id = coalesce(
-    local.remote.aks_clusters[var.aks_clusters[var.aks_cluster_key].lz_key][var.aks_cluster_key].identity[0].principal_id,
-    local.remote.managed_identities[var.aks_clusters[var.aks_cluster_key].identity.lz_key][var.aks_clusters[var.aks_cluster_key].identity.
-    managed_identity_key].principal_id,
-    var.aks_clusters[var.aks_cluster_key].identity.principal_id
+  principal_id         = coalesce(
+    try(local.remote.aks_clusters[var.aks_clusters[var.aks_cluster_key].lz_key][var.aks_cluster_key].identity[0].principal_id, null),
+    try(local.remote.managed_identities[var.aks_clusters[var.aks_cluster_key].identity.lz_key][var.aks_clusters[var.aks_cluster_key].identity.managed_identity_key].principal_id, null),
+    try(var.aks_clusters[var.aks_cluster_key].identity.principal_id, null)
   )
 }
 

--- a/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
+++ b/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
@@ -26,7 +26,7 @@ resource "azurerm_role_assignment" "kubelet_noderg_vmcontrib" {
 
 # Separate subnet
 resource "azurerm_role_assignment" "kubelet_subnets_networkcontrib" {
-  for_each = lookup(var.vnets[var.aks_cluster_vnet_key], "subnet_keys", { vnet = true })
+  for_each = toset(lookup(var.vnets[var.aks_cluster_vnet_key], "subnet_keys", [true]))
 
   scope                = try(each.value == true, false) ? local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].id : local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].subnets[each.value].id
   role_definition_name = "Network Contributor"

--- a/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
+++ b/caf_solution/add-ons/aks_secure_baseline_v2/aks-pod-identity-assignment.tf
@@ -30,7 +30,11 @@ resource "azurerm_role_assignment" "kubelet_subnets_networkcontrib" {
 
   scope                = try(each.value == true, false) ? local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].id : local.remote.vnets[var.vnets[var.aks_cluster_vnet_key].lz_key][var.vnets[var.aks_cluster_vnet_key].key].subnets[each.value].id
   role_definition_name = "Network Contributor"
-  principal_id         = local.remote.aks_clusters[var.aks_clusters[var.aks_cluster_key].lz_key][var.aks_cluster_key].identity[0].principal_id
+  principal_id         = coalesce(
+    try(local.remote.aks_clusters[var.aks_clusters[var.aks_cluster_key].lz_key][var.aks_cluster_key].identity[0].principal_id, null),
+    try(local.remote.managed_identities[var.aks_clusters[var.aks_cluster_key].identity.lz_key][var.aks_clusters[var.aks_cluster_key].identity.managed_identity_key].principal_id, null),
+    try(var.aks_clusters[var.aks_cluster_key].identity.principal_id, null)
+  )
 }
 
 # # Whole vnet
@@ -56,9 +60,10 @@ locals {
       [
         for key, value in var.managed_identities : [
           for msi_key in value.msi_keys : {
-            key     = key
-            msi_key = msi_key
-            id      = local.remote.managed_identities[value.lz_key][msi_key].id
+            key          = key
+            msi_key      = msi_key
+            id           = local.remote.managed_identities[value.lz_key][msi_key].id
+            principal_id = local.remote.managed_identities[value.lz_key][msi_key].principal_id
           }
         ]
       ]


### PR DESCRIPTION
## Description

aks-secure-baseline add-on doesn't work when using an user-assigned identity (user-msi)

**To Reproduce**
Steps to reproduce the behavior:
1. Create an AKS Cluster using UserAssigned identity
2. Apply the aks-secure-baseline (v1 or v2) add-on on the configuration
3. See error in the below screenshot 

**Expected behavior**
The principal id value cannot be null when you do a role assignment. This value needs to be fetched from managed identity  and used while doing the role assignment using the user msi.

**Screenshots**
<img width="1174" alt="Add-on_UserMSI-AKS" src="https://user-images.githubusercontent.com/42051002/128974010-bab9d9c5-2746-429f-94a0-b3d1da94dd6d.png">

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Testing
Testing done with an aks cluster created with user assigned identity. Sample tfvars snippet below:
```
aks_clusters = {
  cluster_dev_temp = {
      lz_key = "lz_key_for_aks"
      key = "cluster_key"
      identity = {
          type = "UserAssigned"
          managed_identity_key = "msi_key"
          lz_key = "lz_key_for_msi"
      }
   }
}

```

### [237](https://github.com/Azure/caf-terraform-landingzones/issues/237)

