### PR TITLE
Auxiliary tenant is optional when peering in the same tenant

### DIFF
--- a/caf_solution/add-ons/cross_tenant_hub_connection/providers.tf
+++ b/caf_solution/add-ons/cross_tenant_hub_connection/providers.tf
@@ -42,7 +42,7 @@ provider "azurerm" {
 
   # Source tenants for virtual networks.
   # Client ID must have permissions on those virtual_networks
-  auxiliary_tenant_ids = var.landingzone.tfstates[var.virtual_hub_lz_key].auxiliary_tenant_ids
+  auxiliary_tenant_ids = try(var.landingzone.tfstates[var.virtual_hub_lz_key].auxiliary_tenant_ids, null)
 }
 provider "azurerm" {
   features {}


### PR DESCRIPTION
The add-on can be used to connect a vnet and a vhub in different subscriptions / same tenant or different tenant.
This change adds the support for the same tenant when using azure AD service principals.

```hcl
virtual_hub_subscription_id = "xxxx"
virtual_hub_tenant_id       = "yyyy"
virtual_hub_lz_key          = "connectivity_virtual_hub1"

virtual_network_subscription_id = "uuuuu"
virtual_network_tenant_id       = "vvvv"

virtual_hub_connections = {
  project2_to_hub1 = {
    name = "project2-to-hub1"
    virtual_hub = {
      lz_key = "connectivity_virtual_hub1"
      key    = "hub1"
    }
    vnet = {
      lz_key   = "project2-resources"
      vnet_key = "project2"
    }
  }
}
```