### PR TITLE
Use correct attribute name for ACR

### DIFF
--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -60,7 +60,7 @@ locals {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azurerm_firewalls, {}))
     }
     container_registry = {
-      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].container_registry, {}))
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azure_container_registries, {}))
     }
     disk_encryption_sets = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].disk_encryption_sets, {}))


### PR DESCRIPTION
ACR entries are stored as `azure_container_registries` in the state file. This PR corrects the attribute name so that an ACR declared in a remote lz can be used.

e.g.
```
{
  "outputs":{
    "objects":{
      "value":{
        "lz_key":{
          "azure_container_registries":{
            "acr1":{ ... }
          }
        }
      }
    }
  }
}
```

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
Try referencing an ACR declared in a remote lz, e.g. for role mapping

```
role_mapping = {
  built_in_role_mapping = {
    azure_container_registries = {
      acr1 = {
        lz_key = "remote_lz"
        "AcrPull" = {
          aks_clusters = {
            keys = ["cluster_re1"]
          }
        }
      }
    }
  }
}
```
