### PR TITLE
Add support for cosmosdb_sql_databases

### DIFF
--- a/caf_solution/local.database.tf
+++ b/caf_solution/local.database.tf
@@ -5,6 +5,7 @@ locals {
       app_config                         = var.app_config
       azurerm_redis_caches               = var.azurerm_redis_caches
       cosmos_dbs                         = var.cosmos_dbs
+      cosmosdb_sql_databases             = var.cosmosdb_sql_databases
       databricks_workspaces              = var.databricks_workspaces
       machine_learning_workspaces        = var.machine_learning_workspaces
       mariadb_databases                  = var.mariadb_databases

--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -62,6 +62,9 @@ locals {
     container_registry = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].container_registry, {}))
     }
+    cosmos_dbs = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].cosmos_dbs, {}))
+    }
     disk_encryption_sets = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].disk_encryption_sets, {}))
     }

--- a/caf_solution/variables.database.tf
+++ b/caf_solution/variables.database.tf
@@ -7,6 +7,9 @@ variable "azurerm_redis_caches" {
 variable "cosmos_dbs" {
   default = {}
 }
+variable "cosmosdb_sql_databases" {
+  default = {}
+}
 variable "database" {
   description = "Database configuration objects"
   default     = {}


### PR DESCRIPTION
Changes to enable a CosmosDB SQL Database to be defined independently of a CosmosDB Account. Allows you to create a shared account in one LZ and add project-specific databases in different LZs. 

Requires https://github.com/aztfmod/terraform-azurerm-caf/pull/725

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

Create a cosmosdb account in one lz and the cosmosdb_sql_account in another, e.g.

Level 3 - application infrastructure lz
```
landingzone = {
  backend_type        = "azurerm"
  global_settings_key = "connectivity"
  level               = "level3"
  key                 = "application_infra"
  tfstates = {
    connectivity = {
      level   = "lower"
      tfstate = "connectivity.tfstate"
    }
  }
}

resource_groups = {
  cosmos_re1 = {
    name   = "rg-cosmos-shared"
    region = "region1"
  }
}

cosmos_dbs = {
  cosmosdb_account_shared = {
    name                      = "cosmos-shared"
    resource_group_key        = "cosmos_re1"
    offer_type                = "Standard"
    kind                      = "GlobalDocumentDB"
    enable_automatic_failover = "true"

    consistency_policy = {
      consistency_level = "Session"
    }

    geo_locations = {
      # Primary location (Write Region)
      primary_geo_location = {
        prefix            = "customid-101"
        region            = "region1"
        zone_redundant    = false
        failover_priority = 0
      }

      # failover location
      failover_geo_location = {
        region            = "region2"
        failover_priority = 1
      }
    }

    # Optional
    enable_free_tier                = false
    enable_multiple_write_locations = false

    private_endpoints = {
      # Require enforce_private_link_endpoint_network_policies set to true on the subnet
      cosmos_db_pe1 = {
        name               = "cosmos-private-endpoint"
        resource_group_key = "cosmos_re1"

        lz_key     = "connectivity"
        vnet_key   = "spoke"
        subnet_key = "db"

        private_service_connection = {
          name                 = "cosmos-private-link"
          is_manual_connection = false
          subresource_names    = ["Sql"]
        }

        private_dns = {
          zone_group_name = "cosmos-private-dns"
          lz_key          = "connectivity"
          keys            = ["cosmos_dns"]
        }
      }
    }
  }
}
```

Level 4 - project lz
```
landingzone = {
  backend_type        = "azurerm"
  global_settings_key = "application_infra"
  level               = "level4"
  key                 = "project"
  tfstates = {
    application_infra = {
      level   = "lower"
      tfstate = "application_infra.tfstate"
    }
  }
}

cosmosdb_sql_databases = {
  project_database = {
    name                 = "cosmosdb-sql-project"
    cosmosdb_account_key = "cosmosdb_account_shared"
    lz_key               = "application_infra"
    throughput           = 400
    containers = {
      container1 = {
        name               = "container1"
        partition_key_path = "/partition_key_path"
        throughput         = 400
      }
    }
  }
}
``` 