### PR TITLE
Add support for Github service connections

### DIFF
--- a/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.github.tf
+++ b/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.github.tf
@@ -1,0 +1,31 @@
+
+# To support cross subscription
+data "external" "github_pat" {
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, null) == "Github"
+  }
+
+  program = [
+    "bash", "-c",
+    format(
+      "az keyvault secret show --id '%s'secrets/'%s' --query '{value: value}' -o json",
+      local.remote.keyvaults[each.value.keyvault.lz_key][each.value.keyvault.key].vault_uri,
+      each.value.keyvault.secret_name
+    )
+  ]
+}
+
+resource "azuredevops_serviceendpoint_github" "serviceendpoint_github" {
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, null) == "Github"
+  }
+
+  project_id            = data.azuredevops_project.project[each.value.project_key].id
+  service_endpoint_name = each.value.endpoint_name
+
+  auth_personal {
+    personal_access_token = data.external.github_pat[each.key].result.value
+  }
+}

--- a/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.tf
+++ b/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.tf
@@ -1,7 +1,11 @@
 
 # To support cross subscription
 data "external" "client_secret" {
-  for_each = var.service_endpoints
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "TfsGit") == "TfsGit"
+  }
+
   program = [
     "bash", "-c",
     format(
@@ -13,7 +17,10 @@ data "external" "client_secret" {
 }
 
 resource "azuredevops_serviceendpoint_azurerm" "azure" {
-  for_each = var.service_endpoints
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "TfsGit") == "TfsGit"
+  }
 
   project_id            = data.azuredevops_project.project[each.value.project_key].id
   service_endpoint_name = each.value.endpoint_name
@@ -31,7 +38,10 @@ resource "azuredevops_serviceendpoint_azurerm" "azure" {
 #
 
 resource "azuredevops_resource_authorization" "endpoint" {
-  for_each = var.service_endpoints
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "TfsGit") == "TfsGit"
+  }
 
   project_id  = data.azuredevops_project.project[each.value.project_key].id
   resource_id = azuredevops_serviceendpoint_azurerm.azure[each.key].id

--- a/caf_solution/add-ons/azure_devops_v1/readme.md
+++ b/caf_solution/add-ons/azure_devops_v1/readme.md
@@ -26,7 +26,55 @@ Azure Devops (example):
   - sample yaml attached [here](./scenario/200-contoso_demo/pipeline/rover.yaml).
 
 Azure:
-* PAT Token   : PAT Token should be updated in keyvault secret that deployed by launchpad LZ as below
+* AZDO PAT Token   : PAT Token should be updated in keyvault secret that deployed by launchpad LZ as below
+* Github PAT Token : If building from repos hosted in Github, a Github PAT Token should be added to a keyvault secret.
+
+
+## Pipelines
+AZDO supports creating pipelines from a number of sources, such as AZDO itself, Github, Bitbucket,
+etc. For repos hosted in Github, you must configure a [service connection][https://docs.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints].
+
+To do this, create a Github PAT token (repo read access is sufficient), and add it to a KeyVault (we
+recommend the 'secrets' KeyVault typically provisioned in level0). Then provide the following config
+directive to configure the connection:
+
+```
+service_endpoints = {
+  github_endpoint = {
+    endpoint_name = "github_endpoint"
+    type = "Github"
+    project_key = "my_project""
+    keyvault = {
+      lz_key      = "launchpad"
+      key         = "secrets"
+      secret_name = "github-pat"
+    }
+  }
+}
+```
+
+When configuring pipelines via the pipelines{} config directive, you can then set the following
+parameters:
+
+```
+pipelines = {
+  launchpad = {
+    project_key      = "my_project"
+    repo_project_key = "my_project_repo"
+    name             = "launchpad"
+    folder           = "\\configuration\\level0"
+    yaml             = "configuration/dev/pipelines/test.yml"
+    repo_type        = "GitHub"
+    git_repo_name    = "github_org/repo_name"
+    branch_name      = "main"
+    service_connection_key = "github_endpoint"
+    variables = {
+      ...
+    }
+  }
+}
+```
+
 
 ![](./documentation/images/pat_token.png)
 


### PR DESCRIPTION
## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

In order to source pipeline yamls from Github (non public repos), we
need to create a service connection.

This commit updates the service endpoint functionality to understand a
'type' value. For the existing configs, default type to 'TfsGit' if none
is specified. If type is set to 'Github', then use the new logic under
azdo_service_endpoint.github.tf to provision the connection.

The various values for 'type' are shown at https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition#repo_type - however this commit only implements Github.
A similar pattern should be possible to implement Bitbucket / GitHubEnterprise.

NOTE: similar to azdo-pat-admin, a Github PAT must be manually created
and stored in the keyvault identified in the 'keyvault {}' block:

$ az keyvault secret set --name gitub-pat --vault-name <secrets-vault> --value <pat>

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
