### PR TITLE
Remove unused var from azure_devops_v1

### DIFF
--- a/caf_solution/add-ons/azure_devops_v1/scenario/200-contoso_demo/projects.tfvars
+++ b/caf_solution/add-ons/azure_devops_v1/scenario/200-contoso_demo/projects.tfvars
@@ -1,5 +1,3 @@
-organization_url = "https://dev.azure.com/azure-terraform"
-
 projects = {
   contoso_demo = {
     create      = true

--- a/caf_solution/add-ons/azure_devops_v1/variables.tf
+++ b/caf_solution/add-ons/azure_devops_v1/variables.tf
@@ -55,9 +55,6 @@ variable "tags" {
 variable "organization_agent_pools" {
   default = {}
 }
-variable "organization_url" {
-  default = null
-}
 variable "projects" {
   default = {}
 }


### PR DESCRIPTION
## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

organization_url doesn't appear to be used anywhere - remove from
examples and module to avoid confusion.

```bash
$ grep -ri organization_url caf-terraform-landingzones caf-terraform-landingzones-starter
caf-terraform-landingzones/caf_solution/add-ons/azure_devops_v1/scenario/200-contoso_demo/projects.tfvars:organization_url = "https://dev.azure.com/azure-terraform"
caf-terraform-landingzones/caf_solution/add-ons/azure_devops_v1/variables.tf:variable "organization_url" {
```

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
