### PR TITLE
Support aad_apps for AZDO service endpoints

### DIFF
--- a/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.tf
+++ b/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoint.tf
@@ -18,10 +18,16 @@ resource "azuredevops_serviceendpoint_azurerm" "azure" {
   project_id            = data.azuredevops_project.project[each.value.project_key].id
   service_endpoint_name = each.value.endpoint_name
   credentials {
-    serviceprincipalid  = local.remote.azuread_applications[each.value.azuread_application.lz_key][each.value.azuread_application.key].application_id
+    serviceprincipalid = try(
+      local.remote.azuread_applications[each.value.azuread_application.lz_key][each.value.azuread_application.key].application_id,
+      local.remote.aad_apps[each.value.azuread_application.lz_key][each.value.azuread_application.key].azuread_application.application_id
+    )
     serviceprincipalkey = data.external.client_secret[each.key].result.value
   }
-  azurerm_spn_tenantid      = local.remote.azuread_applications[each.value.azuread_application.lz_key][each.value.azuread_application.key].tenant_id
+  azurerm_spn_tenantid = try(
+    local.remote.azuread_applications[each.value.azuread_application.lz_key][each.value.azuread_application.key].tenant_id,
+    local.remote.aad_apps[each.value.azuread_application.lz_key][each.value.azuread_application.key].tenant_id
+  )
   azurerm_subscription_id   = each.value.subscription.id
   azurerm_subscription_name = each.value.subscription.name
 }


### PR DESCRIPTION
## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

For reasons that are not entirely clear to me yet, CAF Terraform
has two ways of creating service principals:

```
aad_apps {
  # uses ./modules/azuread/applications
}
```

or,

```
azuread_applications {
  # uses ./modules/azuread/applications_v1
}
```

Also for reasons not yet clear to me, this repo provides two lzs for
configuring AZDO: caf_solution/add-ons/azure_devops and
caf_solution/add-ons/azure_devops_v1

The azure_devops module appears to use aad_apps, while azure_devops_v1
uses azuread_applications. This commit updates azure_devops_v1 to
support both forms of AD config.


## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
