### PR TITLE
Remove unused var from add-ons/aad-pod-identity

### DIFF
--- a/caf_solution/add-ons/aad-pod-identity/variables.tf
+++ b/caf_solution/add-ons/aad-pod-identity/variables.tf
@@ -24,9 +24,6 @@ variable "tags" {
 variable "aks_cluster_key" {
   description = "AKS cluster key to deploy the Gitlab Helm charts. The key must be defined in the variable aks_clusters"
 }
-variable "aks_cluster_vnet_key" {
-
-}
 variable "aks_clusters" {}
 variable "vnets" {
   default = {}


### PR DESCRIPTION
aks_cluster_vnet_key isn't used anywhere in this addon, but there's no
default so terraform will make you supply one. Remove it.

# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
