### PR TITLE
Call file function for helm_release values

### DIFF
--- a/caf_solution/add-ons/aks_applications/app/module.tf
+++ b/caf_solution/add-ons/aks_applications/app/module.tf
@@ -21,7 +21,7 @@ resource "helm_release" "charts" {
   timeout          = try(each.value.timeout, 900)
   skip_crds        = try(each.value.skip_crds, false)
   create_namespace = try(each.value.create_namespace, false)
-  values           = try(each.value.values, null)
+  values           = try(file(each.value.values), null)
 
   dynamic "set" {
     for_each = try(each.value.sets, {})
@@ -41,7 +41,4 @@ resource "helm_release" "charts" {
 
 
   # depends_on = [kubernetes_namespace.namespaces]
-  #   values = [
-  #     "${file("values.yaml")}"
-  #   ]
 }


### PR DESCRIPTION
This change allows us to pass a values.yaml file to this module:

```
helm_charts = {
  traefik = {
    name = "traefik"
    repository = "https://helm.traefik.io/traefik"
    chart      = "traefik"
    namespace  = "kube-system"
    values     = "traefik/values.yaml"
  }
}
```

Where traefik/values.yaml is a file alongside your other configuration.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
