### PR TITLE
Add monitor_autoscale_setting(s) module

### DIFF
--- a/caf_solution/local.shared_services.tf
+++ b/caf_solution/local.shared_services.tf
@@ -2,13 +2,14 @@ locals {
   shared_services = merge(
     var.shared_services,
     {
-      automations              = var.automations
-      recovery_vaults          = var.recovery_vaults
-      monitoring               = var.monitoring
-      shared_image_galleries   = var.shared_image_galleries
-      image_definitions        = var.image_definitions
-      packer_service_principal = var.packer_service_principal
-      packer_managed_identity  = var.packer_managed_identity
+      automations                = var.automations
+      recovery_vaults            = var.recovery_vaults
+      monitoring                 = var.monitoring
+      shared_image_galleries     = var.shared_image_galleries
+      monitor_autoscale_settings = var.monitor_autoscale_settings
+      image_definitions          = var.image_definitions
+      packer_service_principal   = var.packer_service_principal
+      packer_managed_identity    = var.packer_managed_identity
     }
   )
 }

--- a/caf_solution/variables.shared_services.tf
+++ b/caf_solution/variables.shared_services.tf
@@ -35,3 +35,8 @@ variable "recovery_vaults" {
 variable "shared_image_galleries" {
   default = {}
 }
+
+variable "monitor_autoscale_settings" {
+  default = {}
+  description = "The map from the monitor_autoscale_settings module configuration"
+}


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

Adds support for the [azurerm_monitor_autoscale_setting](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) resource.

Related to [PR 803](https://github.com/aztfmod/terraform-azurerm-caf/pull/803) from the [terraform-azurerm-caf](https://github.com/aztfmod/terraform-azurerm-caf) repository.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->