### PR TITLE
Allow full kustomisation of aad-msi-binding.yaml

### DIFF
--- a/caf_solution/add-ons/aad-pod-identity/aad-msi-binding.yaml
+++ b/caf_solution/add-ons/aad-pod-identity/aad-msi-binding.yaml
@@ -1,9 +1,12 @@
 # https://github.com/Azure/aad-pod-identity/blob/b3ee1d07209f26c47a96abf3ba20749932763de6/website/content/en/docs/Concepts/azureidentity.md
+#
+# Note, while the ${} values are not required for kustomize to work, they signify which values are
+# eligible for configuration.
 
 apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentity
 metadata:
-    name: podmi-caf-rover-platform-level0
+    name: ${azureidentity_name}
 spec:
     type: 0
     resourceID: ${resource_id}
@@ -12,8 +15,8 @@ spec:
 apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentityBinding
 metadata:
-    name: podmi-gitlab-runner-binding
+    name: ${azureidentitybinding_name}
 spec:
-    azureIdentity: podmi-caf-rover-platform-level0
-    selector: podmi-caf-rover-platform-level0
+    azureIdentity: ${azureidentity_name}
+    selector: ${azureidentity_selector}
 


### PR DESCRIPTION
Currently the name of the `AzureIdentity` / `AzureIdentityBinding` objects
created as part of the `aad-pod-identity` lz addon have hardcoded names.
This made it not possible to create more than one pair for one MSI.

This patch applies `kustomise` to each field allowing for more
customisation.

It also adds a new 'selector' argument in the case the user doesn't want
the name of the MSI used in this field:

```
managed_identities = {
  ingress_msi = {
    lz_key = "aks"
    aadpodidentity_selector = "ingress"
    msi_keys = [
      "ingress",
    ]
  }
}
```

If `aadpodidentity_selector` is not specified the MSI name is used as
before.

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
