### PR TITLE
Add module for configuring SecretClass for CSI

### DIFF
--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/README.md
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/README.md
@@ -1,0 +1,36 @@
+# Overview
+
+This module provides a method to configure and apply a `SecretProviderClass` object, which is
+required to use the `secrets-store-csi-driver-provider-azure` AKS addon.
+
+Note, similar to the `aad-pod-identity` module (`caf_solution/add-ons/aad-pod-identity`), this
+module does not install the addon itself. This can be accomplished in a number of ways, including
+manually, via Flux, or using helm via `caf_solution/add-ons/aks_applications`.
+
+# Prerequisites
+
+* An AKS cluster
+* The `aad-pod-identity` addon
+* The `secrets-store-csi-driver-provider-azure` addon
+
+# Usage
+
+```
+aks_cluster_key = "cluster_re1"
+
+aks_clusters = {
+  cluster_re1 = {
+    lz_key = "aks"
+    key    = "cluster_re1"
+  }
+}
+
+csi_keyvault_provider = {
+  namespace                = "kube-system"
+  create                   = false
+  secretproviderclass_name = "azure-tls"
+  secret_name              = "azure-tls"
+  cert_name                = "wildcard-ingress"
+  keyvault_name            = "kv-app-gateway-certs"
+}
+```

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/backend.azurerm
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/backend.azurerm
@@ -1,0 +1,4 @@
+terraform {
+    backend "azurerm" {
+    }
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/kustomization_build.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/kustomization_build.tf
@@ -1,0 +1,16 @@
+resource "kustomization_resource" "p0" {
+  for_each = var.settings.ids_prio[0]
+  manifest = var.settings.manifests[each.value]
+}
+
+resource "kustomization_resource" "p1" {
+  depends_on = [kustomization_resource.p0]
+  for_each   = var.settings.ids_prio[1]
+  manifest   = var.settings.manifests[each.value]
+}
+
+resource "kustomization_resource" "p2" {
+  depends_on = [kustomization_resource.p1]
+  for_each   = var.settings.ids_prio[2]
+  manifest   = var.settings.manifests[each.value]
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/main.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/main.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    kustomization = {
+      source = "kbst/kustomization"
+    }
+  }
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/variables.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/build/variables.tf
@@ -1,0 +1,2 @@
+variable "settings" {
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/csi_keyvault_provider.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/csi_keyvault_provider.tf
@@ -1,0 +1,109 @@
+resource "kubernetes_namespace" "ns" {
+  count = var.csi_keyvault_provider.namespace != {} && try(var.csi_keyvault_provider.create, true) ? 1 : 0
+
+  metadata {
+    name = var.csi_keyvault_provider.namespace
+  }
+}
+
+module "build" {
+  depends_on = [kubernetes_namespace.ns]
+  source     = "./build"
+  settings   = data.kustomization_overlay.csi_keyvault_provider
+}
+
+data "kustomization_overlay" "csi_keyvault_provider" {
+  resources = [
+    "secretproviderclass.yaml",
+  ]
+
+  namespace = var.csi_keyvault_provider.namespace
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /metadata/name
+        value: ${var.csi_keyvault_provider.secretproviderclass_name}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/secretObjects/0/secretName
+        value: ${var.csi_keyvault_provider.secret_name}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/secretObjects/0/data/0/objectName
+        value: ${var.csi_keyvault_provider.cert_name}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/secretObjects/0/data/1/objectName
+        value: ${var.csi_keyvault_provider.cert_name}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/parameters/keyvaultName
+        value: ${var.csi_keyvault_provider.keyvault_name}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/parameters/objects
+        value: |
+          array:
+            - |
+              objectName: ${var.csi_keyvault_provider.cert_name}
+              objectType: secret
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+
+  patches {
+    patch = <<-EOF
+      - op: replace
+        path: /spec/parameters/tenantId
+        value: ${try(var.csi_keyvault_provider.keyvault_tenant_id, data.azurerm_client_config.current.tenant_id)}
+    EOF
+
+    target = {
+      kind = "SecretProviderClass"
+    }
+  }
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/local.remote_tfstates.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/local.remote_tfstates.tf
@@ -1,0 +1,46 @@
+locals {
+  landingzone = {
+    current = {
+      storage_account_name = var.tfstate_storage_account_name
+      container_name       = var.tfstate_container_name
+      resource_group_name  = var.tfstate_resource_group_name
+    }
+    lower = {
+      storage_account_name = var.lower_storage_account_name
+      container_name       = var.lower_container_name
+      resource_group_name  = var.lower_resource_group_name
+    }
+  }
+}
+
+data "terraform_remote_state" "remote" {
+  for_each = try(var.landingzone.tfstates, {})
+
+  backend = var.landingzone.backend_type
+  config = {
+    storage_account_name = local.landingzone[try(each.value.level, "current")].storage_account_name
+    container_name       = try(each.value.container, local.landingzone[try(each.value.level, "current")].container_name)
+    resource_group_name  = local.landingzone[try(each.value.level, "current")].resource_group_name
+    subscription_id      = var.tfstate_subscription_id
+    key                  = each.value.tfstate
+  }
+}
+
+locals {
+  landingzone_tag = {
+    "landingzone" = var.landingzone.key
+  }
+
+  global_settings = data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.objects[var.landingzone.global_settings_key].global_settings
+  diagnostics     = data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.objects[var.landingzone.global_settings_key].diagnostics
+
+  remote = {
+    tags            = merge(local.global_settings.tags, local.landingzone_tag, { "level" = var.landingzone.level }, { "environment" = local.global_settings.environment }, { "rover_version" = var.rover_version }, var.tags)
+    global_settings = local.global_settings
+    diagnostics     = local.diagnostics
+
+    aks_clusters = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].aks_clusters, {}))
+    }
+  }
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/main.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.55.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0.2"
+    }
+    kustomization = {
+      source  = "kbst/kustomization"
+      version = "~> 0.5.0"
+    }
+  }
+  required_version = ">= 0.13"
+}
+
+data "azurerm_client_config" "current" {}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/output.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/output.tf
@@ -1,0 +1,3 @@
+output "manifests" {
+  value = data.kustomization_overlay.csi_keyvault_provider
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/providers.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/providers.tf
@@ -1,0 +1,40 @@
+
+provider "azurerm" {
+  features {
+  }
+}
+
+provider "kubernetes" {
+  host                   = local.k8sconfigs[var.aks_cluster_key].host
+  username               = local.k8sconfigs[var.aks_cluster_key].username
+  password               = local.k8sconfigs[var.aks_cluster_key].password
+  client_certificate     = local.k8sconfigs[var.aks_cluster_key].client_certificate
+  client_key             = local.k8sconfigs[var.aks_cluster_key].client_key
+  cluster_ca_certificate = local.k8sconfigs[var.aks_cluster_key].cluster_ca_certificate
+}
+
+provider "kustomization" {
+  kubeconfig_raw = local.k8sconfigs[var.aks_cluster_key].kube_admin_config_raw
+}
+
+locals {
+  k8sconfigs = {
+    for key, value in var.aks_clusters : key => {
+      kube_admin_config_raw  = data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config_raw
+      host                   = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.host : data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.host
+      username               = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.username : data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.username
+      password               = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.password : data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.password
+      client_certificate     = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.client_certificate) : base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.client_certificate)
+      client_key             = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.client_key) : base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.client_key)
+      cluster_ca_certificate = local.remote.aks_clusters[value.lz_key][value.key].enable_rbac ? base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_admin_config.0.cluster_ca_certificate) : base64decode(data.azurerm_kubernetes_cluster.kubeconfig[key].kube_config.0.cluster_ca_certificate)
+    }
+  }
+}
+
+# Get kubeconfig from AKS clusters
+data "azurerm_kubernetes_cluster" "kubeconfig" {
+  for_each = var.aks_clusters
+
+  name                = local.remote.aks_clusters[each.value.lz_key][each.value.key].cluster_name
+  resource_group_name = local.remote.aks_clusters[each.value.lz_key][each.value.key].resource_group_name
+}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/secretproviderclass.yaml
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/secretproviderclass.yaml
@@ -1,0 +1,25 @@
+# https://azure.github.io/secrets-store-csi-driver-provider-azure/getting-started/usage/#create-your-own-secretproviderclass-object
+
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: ${secretproviderclass_name}
+spec:
+  provider: azure
+  secretObjects:                # secretObjects defines the desired state of synced K8s secret objects
+  - secretName: ${secret_name}  # secretName is what gets provided to the target resource (e.g. ingress controller)
+    type: kubernetes.io/tls
+    data:
+    - objectName: ${cert_name}
+      key: tls.key
+    - objectName: ${cert_name}
+      key: tls.crt
+  parameters:
+    usePodIdentity: "true"
+    keyvaultName: ${keyvault_name}
+    objects: |
+      array:
+        - |
+          objectName: ${cert_name}
+          objectType: secret
+    tenantId: ${keyvault_tenant_id}

--- a/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/variables.tf
+++ b/caf_solution/add-ons/secrets-store-csi-driver-provider-azure/variables.tf
@@ -1,0 +1,26 @@
+# Map of the remote data state for lower level
+variable "lower_storage_account_name" {}
+variable "lower_container_name" {}
+variable "lower_resource_group_name" {}
+
+variable "tfstate_subscription_id" {
+  description = "This value is populated by the rover. subscription id hosting the remote tfstates"
+}
+variable "tfstate_storage_account_name" {}
+variable "tfstate_container_name" {}
+variable "tfstate_key" {}
+variable "tfstate_resource_group_name" {}
+
+variable "landingzone" {}
+variable "rover_version" {
+  default = null
+}
+variable "tags" {
+  default = {}
+}
+
+######
+
+variable "aks_cluster_key" {}
+variable "aks_clusters" {}
+variable "csi_keyvault_provider" {}


### PR DESCRIPTION
This copies the pattern used in `add-ons/aad-pod-identity` to create and
apply a `SecretProviderClass` in AKS.

This is required to sync and mount secrets from KeyVault into pods using
the `secrets-store-csi-driver-provider-azure` AKS addon.


## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
