### PR TITLE
add-ons/azure_devops_v1: add service endpoints for Azure container registry

### DIFF
--- a/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoints.acr.tf
+++ b/caf_solution/add-ons/azure_devops_v1/azdo_service_endpoints.acr.tf
@@ -1,0 +1,36 @@
+data "azurerm_container_registry" "acr" {
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "") == "AzureContainerRegistry"
+  }
+
+  name                = local.remote.azure_container_registries[each.value.azure_container_registry.lz_key][each.value.azure_container_registry.key].name
+  resource_group_name = local.remote.azure_container_registries[each.value.azure_container_registry.lz_key][each.value.azure_container_registry.key].resource_group_name
+}
+
+resource "azuredevops_serviceendpoint_dockerregistry" "acr" {
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "") == "AzureContainerRegistry"
+  }
+
+  project_id            = data.azuredevops_project.project[each.value.project_key].id
+  service_endpoint_name = each.value.endpoint_name
+
+  docker_registry = format("https://%s", data.azurerm_container_registry.acr[each.key].login_server)
+  docker_username = data.azurerm_container_registry.acr[each.key].admin_username
+  docker_password = data.azurerm_container_registry.acr[each.key].admin_password
+  registry_type   = "Others"
+}
+
+resource "azuredevops_resource_authorization" "registry_endpoint" {
+  for_each = {
+    for key, value in var.service_endpoints : key => value
+    if try(value.type, "") == "AzureContainerRegistry"
+  }
+
+  project_id  = data.azuredevops_project.project[each.value.project_key].id
+  resource_id = azuredevops_serviceendpoint_dockerregistry.acr[each.key].id
+  type        = "endpoint"
+  authorized  = try(each.value.authorized, false)
+}

--- a/caf_solution/add-ons/azure_devops_v1/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/azure_devops_v1/locals.remote_tfstates.tf
@@ -54,6 +54,9 @@ locals {
     azuread_groups = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azuread_groups, {}))
     }
+    azure_container_registries = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azure_container_registries, {}))
+    }
     keyvaults = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].keyvaults, {}))
     }


### PR DESCRIPTION
<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Introduces a new component `service_endpoints_acr` to add a Docker Registry service connection to Azure DevOps from an Azure Container registry created in a previous landing zone.
It uses the `azuredevops_serviceendpoint_dockerregistry` resource rather than the `azuredevops_serviceendpoint_azurecr` resource, as the latter requires to be able to create a service principal for connecting to the ACR on demand, which seems not feasible to me.

The component requires an existing `azure_container_registries` with `admin_enabled`.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
