### PR TITLE
remove azurerm provider requirements

### DIFF
--- a/caf_solution/add-ons/azure_devops/main.tf
+++ b/caf_solution/add-ons/azure_devops/main.tf
@@ -1,9 +1,6 @@
 terraform {
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.81.0"
-    }
+    // azurerm version driven by the caf module
     azuread = {
       source  = "hashicorp/azuread"
       version = "~> 1.4.0"

--- a/caf_solution/add-ons/azure_devops_agent/main.tf
+++ b/caf_solution/add-ons/azure_devops_agent/main.tf
@@ -1,9 +1,6 @@
 terraform {
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = "~> 2.81.0"
-    }
+    // azurerm version driven by the caf module
     azuread = {
       source  = "hashicorp/azuread"
       version = "~> 1.4.0"


### PR DESCRIPTION
<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

https://github.com/Azure/caf-terraform-landingzones/commit/45b14a4d7b3326e5351dc7b7a18a8035b9882c04 introduced in issue in the azure_devops and azure_devops_agent add-ons which leads to conflict in azurerm provider requirements:

│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/azurerm: no available releases match the given constraints ~> 2.55.0, ~> 2.81.0

Both add-ons are still pinned to version 5.3.0 of the aztfmod/caf/azurerm module. This itself has a requirement on 2.55.0 of the azurerm provider, thus the conflict.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
