### PR TITLE
Add ACR to azure_devops_v1 remote objects

### DIFF
--- a/caf_solution/add-ons/azure_devops_v1/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/azure_devops_v1/locals.remote_tfstates.tf
@@ -71,5 +71,8 @@ locals {
     subscriptions = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].subscriptions, {}))
     }
+    azure_container_registries = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azure_container_registries, {}))
+    }
   }
 }


### PR DESCRIPTION
Interacting with an ACR is common scenario within an AZDO pipeline.

This commit makes it possible to reference ACRs in AZDO variable groups:

```
variable_groups = {
  global_remote_objects = {
    project_key    = "my_project"
    name           = "release-global-remote-objects"
    allow_access   = true
    remote_objects = true

    variables = {
      acr_login_server = {
        output_key    = "azure_container_registries"
        lz_key        = "gitops_connectivity"
        resource_key  = "my_acr"
        attribute_key = "login_server"
        name          = "MY_ACR_LOGIN_SERVER"
      }
    }
  }
}
```

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
