### PR TITLE
Add ability to specify vwan_key for virtual hubs that are part of a virtual WAN

### DIFF
--- a/caf_solution/add-ons/cross_tenant_hub_connection/hub_connection.tf
+++ b/caf_solution/add-ons/cross_tenant_hub_connection/hub_connection.tf
@@ -9,7 +9,8 @@ resource "null_resource" "wait_for_virtual_hub_state" {
     command = format("%s/scripts/wait.sh", path.module)
 
     environment = {
-      VIRTUAL_HUB_ID = data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_hubs[each.value.virtual_hub.key].id
+      VIRTUAL_HUB_ID = try(data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_hubs[each.value.virtual_hub.key].id,
+        data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_wans[each.value.virtual_hub.vwan_key].virtual_hubs[each.value.virtual_hub.key].id)
     }
   }
 }
@@ -19,7 +20,8 @@ resource "azurerm_virtual_hub_connection" "conn" {
   depends_on = [null_resource.wait_for_virtual_hub_state]
 
   name           = each.value.name
-  virtual_hub_id = data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_hubs[each.value.virtual_hub.key].id
+  virtual_hub_id = try(data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_hubs[each.value.virtual_hub.key].id,
+    data.terraform_remote_state.remote[each.value.virtual_hub.lz_key].outputs.objects[each.value.virtual_hub.lz_key].virtual_wans[each.value.virtual_hub.vwan_key].virtual_hubs[each.value.virtual_hub.key].id)
   remote_virtual_network_id = try(
     each.value.vnet.id,
     data.terraform_remote_state.remote[each.value.vnet.lz_key].outputs.objects[each.value.vnet.lz_key].vnets[each.value.vnet.vnet_key].id


### PR DESCRIPTION
[Add-on cross_tenant_hub_connection does not work with virtual hub that is part of a virtual wan #294](https://github.com/Azure/caf-terraform-landingzones/issues/294)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Add ability to specify vwan_key for virtual hubs that are a part of a virtual wan in the add-on cross_tenant_hub_connection

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
