### PR TITLE
Add support for configuring launchpad purge_soft_delete_on_destroy on Launchpad Key Vaults

### DIFF
--- a/caf_launchpad/main.tf
+++ b/caf_launchpad/main.tf
@@ -28,9 +28,14 @@ terraform {
 
 
 provider "azurerm" {
-  partner_id = "ca4078f8-9bc4-471b-ab5b-3af6b86a42c8"
   # partner identifier for CAF Terraform landing zones.
-  features {}
+  partner_id = "ca4078f8-9bc4-471b-ab5b-3af6b86a42c8"
+
+  features {
+    key_vault {
+      purge_soft_delete_on_destroy = var.provider_azurerm_features_keyvault.purge_soft_delete_on_destroy
+    }
+  }
 }
 
 resource "random_string" "prefix" {

--- a/caf_launchpad/variables.tf
+++ b/caf_launchpad/variables.tf
@@ -236,3 +236,9 @@ variable "route_tables" {
 variable "propagate_launchpad_identities" {
   default = false
 }
+
+variable "provider_azurerm_features_keyvault" {
+  default = {
+    purge_soft_delete_on_destroy = false
+  }
+}


### PR DESCRIPTION
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

Add support for configuring `purge_soft_delete_on_destroy` for launchpad keyvaults. 

If you have `purge_protection_enabled = true` on any of your launchpad keyvaults then the launchpad should not attempt to purge keyvaults/keyvault objects when they are deleted. This PR adds support for that.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->

Bootstrap a launchpad with a keyvault configuration containing `purge_soft_delete_on_destroy`, e.g.

```
keyvaults = {
  level0 = {
    name                     = "kv-mycompany-level0-shared"
    resource_group_key       = "level0"
    sku_name                 = "standard"
    soft_delete_enabled      = true
    purge_protection_enabled = true

    ## These tags must never be changed after being set as they are used by the rover to locate the launchpad and the tfstates
    tags = {
      tfstate = "level0"
    }

    # you can setup up to 5 profiles
    diagnostic_profiles = {
      operations = {
        definition_key   = "default_all"
        destination_type = "log_analytics"
        destination_key  = "central_logs"
      }
      siem = {
        definition_key   = "siem_all"
        destination_type = "storage"
        destination_key  = "all_regions"
      }
    }
  }
}
```

Then attempt to delete the resource, either by destroying the landing zone or by renaming the keyvault. This will trigger a purge operation that will require `purge_soft_delete_on_destroy = false` to be set on the `azurerm` terraform provider.
