### PR TITLE
fixing dns server reference

### DIFF
--- a/templates/asvm/orion/resources.asvm.yaml
+++ b/templates/asvm/orion/resources.asvm.yaml
@@ -15,7 +15,7 @@
         platform:
           virtual_hubs: {{platform_mappings[env]}}
           virtual_hubs_route_tables: {{platform_mappings[env]}}
-          secure_firewalls: {{platform_mappings[env]}}
+          private_dns_firewalls: {{platform_mappings[env]}}
           identity_level2: {{platform_mappings[env]}}
           asvm:
 
@@ -371,7 +371,7 @@
         vnet_to_{{platform_mappings[env]}}:
           name: vnet-{{landingzone_definition}}-{{env}}-TO-{{platform_mappings[env]}}
           virtual_hub:
-            lz_key: connectivity_virtual_hubs_{{platform_mappings[env]}}
+            lz_key: connectivity_virtual_hub_{{platform_mappings[env]}}
             key: {{platform_mappings[env]}}
           vnet:
             vnet_key: vnet

--- a/templates/asvm/orion/resources.asvm.yaml
+++ b/templates/asvm/orion/resources.asvm.yaml
@@ -371,7 +371,7 @@
         vnet_to_{{platform_mappings[env]}}:
           name: vnet-{{landingzone_definition}}-{{env}}-TO-{{platform_mappings[env]}}
           virtual_hub:
-            lz_key: connectivity_virtual_hub_{{platform_mappings[env]}}
+            lz_key: connectivity_virtual_hubs_{{platform_mappings[env]}}
             key: {{platform_mappings[env]}}
           vnet:
             vnet_key: vnet

--- a/templates/asvm/orion/resources.asvm.yaml
+++ b/templates/asvm/orion/resources.asvm.yaml
@@ -45,8 +45,8 @@
           dns_servers_keys:
             fw_secure_{{platform_mappings[env]}}:
               resource_type: azurerm_firewall
-              lz_key: connectivity_secure_firewalls_{{platform_mappings[env]}}
-              key: fw_secure_{{platform_mappings[env]}}
+              lz_key: connectivity_private_dns_firewalls_{{platform_mappings[env]}}
+              key: fw_prod_dns_{{platform_mappings[env]}}
           address_space:
             - 10.101.8.0/23
           subnets:


### PR DESCRIPTION
#346 
## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- can't test because my setup uses different keys. Logic works with my keys in my setup.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

March platform release deploys two firewalls:
Hub attached firewall connectivity_secure_firewalls_env
VNet attached firewall as a central DNS instance connectivity_private_dns_firewalls_env

This change adds to correct firewall as dns server of the newly created VNet.
See the linked issue


## Does this introduce a breaking change

- [x] YES

- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
It will change the current DNS Setting of existing ASVM Subscriptions. In my opinion, this setting is correct.
## Testing
Build a level0 to level3 landingzone based on the march release, then use the asvm to create a hub attached subscription.
In my modified scenario, my change worked fine.