### PR TITLE
Add auth for ACR to aks_applications

### DIFF
--- a/caf_solution/add-ons/aks_applications/app/module.tf
+++ b/caf_solution/add-ons/aks_applications/app/module.tf
@@ -8,21 +8,42 @@ resource "kubernetes_namespace" "namespaces" {
 
 }
 
+# https://docs.microsoft.com/en-us/azure/container-registry/container-registry-helm-repos#authenticate-with-the-registry
+data "external" "password" {
+  for_each = {
+    for key, value in var.helm_charts : key => value
+    if try(value.azure_container_registry, null) != null
+  }
+
+  program = [
+    "bash", "-cx",
+    format(
+      "az acr login --name %s --expose-token --output json --query '{value: accessToken}'",
+      var.azure_container_registries[each.value.azure_container_registry.lz_key][each.value.azure_container_registry.key].name
+    )
+  ]
+}
+
 # https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release
 resource "helm_release" "charts" {
   for_each = var.helm_charts
 
-  name       = each.value.name
-  repository = each.value.repository
-  chart      = each.value.chart
-
-  namespace        = each.value.namespace
-  wait             = try(each.value.wait, true)
-  timeout          = try(each.value.timeout, 900)
-  skip_crds        = try(each.value.skip_crds, false)
-  create_namespace = try(each.value.create_namespace, false)
-  values           = try(each.value.values, null)
-  version          = try(each.value.version, null)
+  name                = each.value.name
+  chart               = each.value.chart
+  namespace           = each.value.namespace
+  wait                = try(each.value.wait, true)
+  timeout             = try(each.value.timeout, 900)
+  skip_crds           = try(each.value.skip_crds, false)
+  create_namespace    = try(each.value.create_namespace, false)
+  values              = try(each.value.values, null)
+  version             = try(each.value.version, null)
+  repository_username = try(each.value.azure_container_registry.username, null)
+  repository_password = try(data.external.password[each.key].result.value, null)
+  repository = try(
+    each.value.repository,
+    format("oci://%s", var.azure_container_registries[each.value.azure_container_registry.lz_key][each.value.azure_container_registry.key].login_server),
+    null
+  )
 
   dynamic "set" {
     for_each = try(each.value.sets, {})

--- a/caf_solution/add-ons/aks_applications/app/variables.tf
+++ b/caf_solution/add-ons/aks_applications/app/variables.tf
@@ -9,3 +9,7 @@ variable "helm_charts" {
 variable "kuztomization_settings" {
   default = {}
 }
+
+variable "azure_container_registries" {
+  default = {}
+}

--- a/caf_solution/add-ons/aks_applications/applications.tf
+++ b/caf_solution/add-ons/aks_applications/applications.tf
@@ -1,5 +1,6 @@
 module "app" {
-  source      = "./app"
-  namespaces  = var.namespaces
-  helm_charts = var.helm_charts
+  source                     = "./app"
+  namespaces                 = var.namespaces
+  helm_charts                = var.helm_charts
+  azure_container_registries = local.remote.azure_container_registries
 }

--- a/caf_solution/add-ons/aks_applications/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/aks_applications/locals.remote_tfstates.tf
@@ -56,6 +56,9 @@ locals {
     vnets = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].vnets, {}))
     }
+    azure_container_registries = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].azure_container_registries, {}))
+    }
   }
 
 }

--- a/caf_solution/add-ons/aks_applications/main.tf
+++ b/caf_solution/add-ons/aks_applications/main.tf
@@ -10,7 +10,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.1.2"
+      version = "~> 2.5.0"
     }
     kustomization = {
       source  = "kbst/kustomization"


### PR DESCRIPTION
This patch allows the use of ACR as a repository for helm charts.

Example usage:

```
helm_charts = {
  mychart = {
    name       = "mychart"
    chart      = "mychart"
    namespace  = "default"
    version    = "0.0.1"

    azure_container_registry = {
      lz_key   = "devops"
      key      = "devops_acr"
      username = "00000000-0000-0000-0000-000000000000"
    }
  }
}
```

Note, the version bump of the helm provider is for the recently added
oci support: https://github.com/hashicorp/terraform-provider-helm/issues/666

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
