### PR TITLE
Adds data factory j2 resource template

### DIFF
--- a/templates/resources/data_factory.tfvars.j2
+++ b/templates/resources/data_factory.tfvars.j2
@@ -1,0 +1,54 @@
+data_factory = {
+{% for key, value in resources[tfstate_resource].resources[subscription_key].data_factory.items() %}
+  {{ key }} = {
+    name = "{{ value.name }}"
+{% if value.resource_group_key is defined %}
+    resource_group_key = "{{ value.resource_group_key }}"
+{% endif %}
+{% if value.resource_group is defined %}
+    resource_group = {
+      key = "{{value.resource_group.key}}"
+{% if value.resource_group.lz_key is defined %}
+      lz_key = "{{ value.resource_group.lz_key }}"
+{% endif %}
+    }
+{% endif %}
+{% if value.managed_virtual_network_enabled is defined %}
+    managed_virtual_network_enabled = {{ value.managed_virtual_network_enabled }}
+{% endif %}
+
+{% if value.private_endpoints is defined %}
+    private_endpoints = {
+{% for pep_key, pep_config in value.private_endpoints.items() %}
+      {{ pep_key }} = {
+        name = "{{pep_config.name}}"
+        vnet_key = "{{pep_config.vnet_key}}"
+        subnet_key = "{{pep_config.subnet_key}}"
+        resource_group_key = "{{pep_config.resource_group_key}}"
+{% if pep_config.identity is defined %}
+        identity = {
+          type = "{{pep_config.identity.type}}"
+          identity_ids = {{pep_config.identity.identity_ids | replace('None','[]') | replace('[', '[\n') | replace(']', '\n]') | replace(',', ',\n') | replace('\'','\"')}}
+        }
+{% endif %}
+        private_service_connection = {
+          name = "{{pep_config.private_service_connection.name}}"
+          is_manual_connection = {{pep_config.private_service_connection.is_manual_connection}}
+          subresource_names = {{pep_config.private_service_connection.subresource_names | replace('None','[]') | replace('[', '[\n') | replace(']', '\n]') | replace(',', ',\n') | replace('\'','\"')}}
+        }
+{% if pep_config.private_dns is defined %}
+        private_dns = {
+          zone_group_name = "{{pep_config.private_dns.zone_group_name}}"
+          keys = {{pep_config.private_dns.zone_keys | replace('None','[]') | replace('[', '[\n') | replace(']', '\n]') | replace(',', ',\n') | replace('\'','\"')}}
+{% if pep_config.private_dns.lz_key is defined %}
+          lz_key = "{{pep_config.private_dns.lz_key}}"
+{% endif %}
+        }
+{% endif %}
+      }
+{% endfor %}
+    }
+{% endif %}
+  }
+{% endfor %}
+}

--- a/templates/resources/data_factory.tfvars.j2
+++ b/templates/resources/data_factory.tfvars.j2
@@ -14,7 +14,7 @@ data_factory = {
     }
 {% endif %}
 {% if value.managed_virtual_network_enabled is defined %}
-    managed_virtual_network_enabled = {{ value.managed_virtual_network_enabled }}
+    managed_virtual_network_enabled = {{ value.managed_virtual_network_enabled | lower }}
 {% endif %}
 
 {% if value.private_endpoints is defined %}
@@ -33,7 +33,7 @@ data_factory = {
 {% endif %}
         private_service_connection = {
           name = "{{pep_config.private_service_connection.name}}"
-          is_manual_connection = {{pep_config.private_service_connection.is_manual_connection}}
+          is_manual_connection = {{pep_config.private_service_connection.is_manual_connection | lower}}
           subresource_names = {{pep_config.private_service_connection.subresource_names | replace('None','[]') | replace('[', '[\n') | replace(']', '\n]') | replace(',', ',\n') | replace('\'','\"')}}
         }
 {% if pep_config.private_dns is defined %}


### PR DESCRIPTION
# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ X ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ X ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Adds j2 template support for the Azure Data Factory (data_factory) resource type.

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [ X ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

data_factory:
        df1:
          name: df1{{landingzone_definition}}{{env}}
          resource_group_key: integration
          managed_virtual_network_enabled: true
          private_endpoints:
            df1-factory:
              name: adf-int-acct
              resource_group_key: integration
              vnet_key: vnet
              subnet_key: private_endpoints
              identity:
                type: SystemAssigned
                identity_ids: None
              private_service_connection:
                name: adf-int-psc
                is_manual_connection: false
                subresource_names:
                  - dataFactory
              private_dns:
                zone_group_name: privatelink.datafactory.azure.net
                zone_keys:
                  - privatelink.datafactory.azure.net
                lz_key: connectivity_private_dns_non_prod

<!-- Instructions for testing and validation of your code -->
