### PR TITLE
Set subscription id and tenant id in custom_variables

### DIFF
--- a/caf_solution/local.custom_variables.tf
+++ b/caf_solution/local.custom_variables.tf
@@ -1,6 +1,6 @@
 locals {
-  connectivity_subscription_id = can(local.tfstates[local.custom_variables.virtual_hub_lz_key].subscription_id) ? local.tfstates[local.custom_variables.virtual_hub_lz_key].subscription_id : data.azurerm_client_config.current.subscription_id
-  connectivity_tenant_id       = can(local.tfstates[local.custom_variables.virtual_hub_lz_key].tenant_id) ? local.tfstates[local.custom_variables.virtual_hub_lz_key].tenant_id : data.azurerm_client_config.current.tenant_id
+  connectivity_subscription_id = can(local.tfstates[local.custom_variables.virtual_hub_lz_key].subscription_id) || can(var.custom_variables.virtual_hub_subscription_id) ? try(var.custom_variables.virtual_hub_subscription_id, local.tfstates[local.custom_variables.virtual_hub_lz_key].subscription_id) : data.azurerm_client_config.current.subscription_id
+  connectivity_tenant_id       = can(local.tfstates[local.custom_variables.virtual_hub_lz_key].tenant_id) || can(var.custom_variables.virtual_hub_tenant_id) ? try(var.custom_variables.virtual_hub_tenant_id, local.tfstates[local.custom_variables.virtual_hub_lz_key].tenant_id) : data.azurerm_client_config.current.tenant_id
 
   remote_custom_variables = {
     for key, value in try(var.landingzone.tfstates, {}) : "deep_merged_l1" => merge(try(data.terraform_remote_state.remote[key].outputs.custom_variables, {}))...

--- a/caf_solution/main.tf
+++ b/caf_solution/main.tf
@@ -2,10 +2,6 @@ terraform {
   required_providers {
     // azurerm version driven by the caf module
     // azuread version driven by the caf module
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.3.0"
-    }
     external = {
       source  = "hashicorp/external"
       version = "~> 2.2.0"

--- a/templates/platform/level1/alz/ansible.yaml
+++ b/templates/platform/level1/alz/ansible.yaml
@@ -8,7 +8,9 @@
     verbosity: 2
 
 - debug:
-    msg: "{{destination_path}}"
+    msg: 
+      - "{{destination_path}}"
+      - "alz-overrite"
 
 - name: "{{ level }}-{{ tfstate }} |  Clean-up base directory"
   shell: |

--- a/templates/platform/level1/alz/lib/v1.1.3/archetype_config_overrides.tfvars.j2
+++ b/templates/platform/level1/alz/lib/v1.1.3/archetype_config_overrides.tfvars.j2
@@ -33,10 +33,10 @@ archetype_config_overrides = {
 {% else %}
       parameters       = {}
 {% endif %}
-{% if level.archetype_resources.access_control is mapping %}
+{% if level.archetype_config.access_control is mapping %}
       access_control = {
 {% if resources.azure_landing_zones.identity.azuread_identity_mode != "logged_in_user" %}
-{% for level_ac_key, level_ac in level.archetype_resources.access_control.items() %}
+{% for level_ac_key, level_ac in level.archetype_config.access_control.items() %}
         "{{level_ac_key}}" = {
 {% for level_role_key, level_role in level_ac.items()  %}
           "{{ level_role_key }}" = {

--- a/templates/platform/level1/alz/lib/v1.1.3/custom_landing_zones.tfvars.j2
+++ b/templates/platform/level1/alz/lib/v1.1.3/custom_landing_zones.tfvars.j2
@@ -36,10 +36,10 @@ custom_landing_zones = {
 {% else %}
       parameters       = {}
 {% endif %}
-{% if level.archetype_resources.access_control is defined %}
+{% if level.archetype_config.access_control is defined %}
       access_control = {
 {% if resources.azure_landing_zones.identity.azuread_identity_mode != "logged_in_user" %}
-{% for level_ac_key, level_ac in level.archetype_resources.access_control.items() %}
+{% for level_ac_key, level_ac in level.archetype_config.access_control.items() %}
         "{{level_ac_key}}" = {
 {% for level_role_key, level_role in level_ac.items()  %}
           "{{ level_role_key }}" = {

--- a/templates/platform/level1/alz/subscription_id_overrides.tfvars.j2
+++ b/templates/platform/level1/alz/subscription_id_overrides.tfvars.j2
@@ -64,23 +64,23 @@ subscription_id_overrides = {
 subscription_id_overrides_by_keys = {
   connectivity = {
     connectivity = {
-      lz_key = "{{ resources.tfstates.platform.subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
+      lz_key = "{{ resources.tfstates.platform.platform_subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
       key    = "connectivity"
     }
   }
   management = {
     launchpad = {
-      lz_key = "{{ resources.tfstates.platform.subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
+      lz_key = "{{ resources.tfstates.platform.platform_subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
       key    = "launchpad"
     }
     management = {
-      lz_key = "{{ resources.tfstates.platform.subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
+      lz_key = "{{ resources.tfstates.platform.platform_subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
       key    = "management"
     }
   }
   identity = {
     identity = {
-      lz_key = "{{ resources.tfstates.platform.subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
+      lz_key = "{{ resources.tfstates.platform.platform_subscriptions.lz_key_name | default(resources.tfstates.platform_subscriptions.subscriptions.lz_key_name) }}"
       key    = "identity"
     }
   }


### PR DESCRIPTION
# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->
Previoulsy to connect a vnet to a vhub in a different subscription, you had to set the global_settings_key to the virtual hub tfstate. With this update you can set the subscription id and tenant id (optional) of the vhub. Terraform will use those values to configure the azurerm.vhub provider alias.

```
custom_variables = {
  virtual_hub_subscription_id = "xxxxxx"
  # virtual_hub_tenant_id = "yyyy"
}
```

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
