### PR TITLE
fix(caf_solution/locals.remote_tfstates.tf): changing order of global_settings…

### DIFF
--- a/caf_solution/locals.remote_tfstates.tf
+++ b/caf_solution/locals.remote_tfstates.tf
@@ -34,7 +34,7 @@ locals {
         sas_token            = try(value.sas_token, null) != null ? var.sas_token : null
         use_azuread_auth     = try(value.use_azuread_auth, true)
       } if try(value.backend_type, "azurerm") == "azurerm"
-    } 
+    }
     remote = {
       for key, value in try(var.landingzone.tfstates, {}) : key => {
         hostname     = try(value.hostname, null)
@@ -46,14 +46,21 @@ locals {
     }
   }
 
-  tags = merge(try(local.global_settings.tags, {}), { "level" = var.landingzone.level }, try({ "environment" = local.global_settings.environment }, {}), { "rover_version" = var.rover_version }, var.tags)
+  tags = merge(
+    try(local.global_settings.tags, {}),
+    { "level" = var.landingzone.level },
+    try({ "environment" = local.global_settings.environment }, {}),
+    { "rover_version" = var.rover_version },
+    var.tags,
+    try(var.global_settings.tags, {}),
+    try(local.custom_variables.tags, {}),
+  )
 
   global_settings = merge(
-    var.global_settings,
     try(data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.objects[var.landingzone.global_settings_key].global_settings, null),
     try(data.terraform_remote_state.remote[var.landingzone.global_settings_key].outputs.global_settings, null),
-    try(data.terraform_remote_state.remote[keys(var.landingzone.tfstates)[0]].outputs.global_settings, null),
-    local.custom_variables
+    try(var.global_settings, {}),
+    try(local.custom_variables, {}),
   )
 
 


### PR DESCRIPTION
... within the merge function

# [Issue-id: 403](https://github.com/Azure/caf-terraform-landingzones/issues/403)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

When defining global_settings block for a given landingzone, the current landingzone should take precedence over global_settings defined in lower/other current landingzones. Also, the global_settings should only be imported when global_settings_key is defined. Since a merge function is used, the order of items in the map are important.

- when reading global_settings the current landingzone global_settings block should be given preference. Since a merge function is used, the order of items in the map are important.
- global_settings from reference tfstate files should only be included if global_settings_key = <landingzone-key> is defined.
- hence, reading global_settings from first tfstate is removed.
try(data.terraform_remote_state.remote[keys(var.landingzone.tfstates)[0]].outputs.global_settings, null),

## Does this introduce a breaking change

- [X ] YES [Potentially]
- [ ] NO

## Testing
Create a landingzone with global_settings [passthrough = true;]
Create another landingzone with global_settings [passthrough = false; prefix=xyz]
Now withing the landingzone.tfvars, reference the 1st landingzone within the tfstate block.
