### PR TITLE
Add remote virtual subnets referencing

### DIFF
--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -229,6 +229,9 @@ locals {
     virtual_machines = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_machines, {}))
     }
+    virtual_subnets = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_subnets, {}))
+    }
     virtual_wans = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].virtual_wans, {}))
     }


### PR DESCRIPTION
# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, there is no option of referencing remote virtual subnets in the context where existing non-CAF virtual networks are provisioned by external vendors due to organisational requirements. As such, there is a constraint referencing a remote virtual network via attribute `vnet_key`. There is a need to reference `subnet_key` directly.

The PR allows for pulling a remote terraform state where the virtual subnets have been created prior, for referencing in current landing zones.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
