### PR TITLE
Add suffixes in global settings

### DIFF
--- a/caf_launchpad/main.tf
+++ b/caf_launchpad/main.tf
@@ -99,11 +99,11 @@ locals {
     inherit_tags       = var.inherit_tags
     passthrough        = var.passthrough
     prefix             = var.prefix
-    prefixes           = var.prefixes == "" ? null : [try(random_string.prefix.0.result, var.prefixes)]
-    prefix_with_hyphen = var.prefixes == "" ? null : format("%s", try(random_string.prefix.0.result, var.prefixes))
+    prefixes           = var.prefix == "" ? null : [try(random_string.prefix.0.result, var.prefix)]
+    prefix_with_hyphen = var.prefix == "" ? null : format("%s", try(random_string.prefix.0.result, var.prefix))
     suffix             = var.suffix
-    suffixes           = var.suffixes == "" ? null : [try(random_string.prefix.0.result, var.suffixes)]
-    suffix_with_hyphen = var.suffixes == "" ? null : format("%s", try(random_string.prefix.0.result, var.suffixes))
+    suffixes           = var.suffix == "" ? null : [try(random_string.prefix.0.result, var.suffix)]
+    suffix_with_hyphen = var.suffix == "" ? null : format("%s", try(random_string.prefix.0.result, var.suffix))
     random_length      = var.random_length
     regions            = var.regions
     tags               = var.tags

--- a/caf_launchpad/main.tf
+++ b/caf_launchpad/main.tf
@@ -99,8 +99,11 @@ locals {
     inherit_tags       = var.inherit_tags
     passthrough        = var.passthrough
     prefix             = var.prefix
-    prefixes           = var.prefix == "" ? null : [try(random_string.prefix.0.result, var.prefix)]
-    prefix_with_hyphen = var.prefix == "" ? null : format("%s", try(random_string.prefix.0.result, var.prefix))
+    prefixes           = var.prefixes == "" ? null : [try(random_string.prefix.0.result, var.prefixes)]
+    prefix_with_hyphen = var.prefixes == "" ? null : format("%s", try(random_string.prefix.0.result, var.prefixes))
+    suffix             = var.suffix
+    suffixes           = var.suffixes == "" ? null : [try(random_string.prefix.0.result, var.suffixes)]
+    suffix_with_hyphen = var.suffixes == "" ? null : format("%s", try(random_string.prefix.0.result, var.suffixes))
     random_length      = var.random_length
     regions            = var.regions
     tags               = var.tags

--- a/caf_launchpad/variables.tf
+++ b/caf_launchpad/variables.tf
@@ -63,6 +63,18 @@ variable "prefix" {
   default = null
 }
 
+variable "prefixes" {
+  default = null
+}
+
+variable "suffix" {
+  default = null
+}
+
+variable "suffixes" {
+  default = null
+}
+
 variable "use_slug" {
   default = true
 }

--- a/caf_launchpad/variables.tf
+++ b/caf_launchpad/variables.tf
@@ -63,15 +63,7 @@ variable "prefix" {
   default = null
 }
 
-variable "prefixes" {
-  default = null
-}
-
 variable "suffix" {
-  default = null
-}
-
-variable "suffixes" {
   default = null
 }
 


### PR DESCRIPTION
# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

The `azurecaf_name` resource (Azurecaf provider) implements a set of methodologies in applying a consistent resource naming using the default Microsoft Cloud Adoption Framework for Azure recommendations. 

The global settings which propagate names, tags etc from the launchpad to subsequent landingzones currently do not have an option to configure for suffixes. This PR attempts to provide the support for suffixes.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
