### PR TITLE
Support monitor_metric_alert

### DIFF
--- a/caf_solution/local.shared_services.tf
+++ b/caf_solution/local.shared_services.tf
@@ -8,6 +8,7 @@ locals {
       log_analytics_storage_insights = var.log_analytics_storage_insights
       monitor_autoscale_settings     = var.monitor_autoscale_settings
       monitor_action_groups          = var.monitor_action_groups
+      monitor_metric_alert           = var.monitor_metric_alert
       monitoring                     = var.monitoring
       packer_managed_identity        = var.packer_managed_identity
       packer_service_principal       = var.packer_service_principal

--- a/caf_solution/variables.shared_services.tf
+++ b/caf_solution/variables.shared_services.tf
@@ -28,6 +28,10 @@ variable "monitor_action_groups" {
   default = {}
 }
 
+variable "monitor_metric_alert" {
+  default = {}
+}
+
 variable "monitoring" {
   default = {}
 }


### PR DESCRIPTION
At the moment, we can't create monitor_metric_alert using [caf-terraform-landingzones](https://github.com/Azure/caf-terraform-landingzones). It is simply missing the variable. Could we please merge this simple PR?

Thank you very much

The root module does not declare a variable named "monitor_metric_alert" but
a value was found in file
"/__w/7/s/configuration/monitor_action_groups.tfvars".

