### PR TITLE
Added subscription_id_identity

### DIFF
--- a/caf_solution/add-ons/caf_eslz/enterprise_scale.tf
+++ b/caf_solution/add-ons/caf_eslz/enterprise_scale.tf
@@ -35,9 +35,11 @@ module "enterprise_scale" {
   disable_telemetry                = var.disable_telemetry
   subscription_id_connectivity     = local.subscription_id_connectivity
   subscription_id_management       = local.subscription_id_management
+  subscription_id_identity         = local.subscription_id_identity
 }
 
 locals {
   subscription_id_connectivity     = var.subscription_id_connectivity == null ? data.azurerm_client_config.current.subscription_id : var.subscription_id_connectivity
   subscription_id_management       = var.subscription_id_management == null ? data.azurerm_client_config.current.subscription_id : var.subscription_id_management
+  subscription_id_identity         = var.subscription_id_identity  == null ? data.azurerm_client_config.current.subscription_id : var.subscription_id_identity
 }

--- a/caf_solution/add-ons/caf_eslz/main.tf
+++ b/caf_solution/add-ons/caf_eslz/main.tf
@@ -31,4 +31,12 @@ provider "azurerm" {
   tenant_id       = var.tenant_id
 }
 
+provider "azurerm" {
+  partner_id = "ca4078f8-9bc4-471b-ab5b-3af6b86a42c8"
+  alias      = "identity"
+  features {}
+  subscription_id = var.subscription_id_identity == null ? data.azurerm_client_config.current.subscription_id : var.subscription_id_identity
+  tenant_id       = var.tenant_id
+}
+
 data "azurerm_client_config" "current" {}

--- a/caf_solution/add-ons/caf_eslz/variables_alz.tf
+++ b/caf_solution/add-ons/caf_eslz/variables_alz.tf
@@ -604,3 +604,9 @@ variable "subscription_id_management" {
   description = "If specified, identifies the Platform subscription for \"Management\" for resource deployment and correct placement in the Management Group hierarchy."
   default     = null
 }
+
+variable "subscription_id_identity" {
+  type        = string
+  description = "If specified, identifies the Platform subscription for \"Identity\" for resource deployment and correct placement in the Management Group hierarchy."
+  default     = null
+}


### PR DESCRIPTION
## Description

Added subscription_id_identity to ES for custom landing zone support

## Does this introduce a breaking change

- [ ] YES
- [X] NO


