### PR TITLE
Add ip_configuration block to private endpoints

### DIFF
--- a/templates/resources/private_endpoints.tfvars.j2
+++ b/templates/resources/private_endpoints.tfvars.j2
@@ -33,6 +33,18 @@ private_endpoints = {
 {% endif %} 
     }
 {% endif %}
+{% if v.ip_configuration is defined %}
+    ip_configuration = {
+      name = "{{v.ip_configuration.name}}"
+      private_ip_address = "{{v.ip_configuration.private_ip_address}}"
+{% if v.ip_configuration.subresource_name is defined %}
+      subresource_name             = "{{v.ip_configuration.subresource_name }}"
+{% endif %}
+{% if v.ip_configuration.member_name is defined %}
+      member_name             = "{{v.ip_configuration.member_name }}"
+{% endif %}
+    }
+{% endif %}
   }
 {% endfor %}
 }


### PR DESCRIPTION
# [Issue-482](https://github.com/Azure/caf-terraform-landingzones/issues/482)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

Currently, it is not possible to define a static IP-address for private endpoints by defining the ip_configuration block, which is supported in the [Private-Endpoint Terraform Resource >3.21.0](https://registry.terraform.io/providers/hashicorp/azurerm/3.21.0/docs/resources/private_endpoint#ip_configuration)

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
