### PR TITLE
aks_applications_v2 should work without AKS keyvault secret provider …

### DIFF
--- a/caf_solution/add-ons/aks_applications_v2/locals.remote_tfstates.tf
+++ b/caf_solution/add-ons/aks_applications_v2/locals.remote_tfstates.tf
@@ -59,5 +59,5 @@ locals {
   kubelogin_cred = {
     secret_prefix = try(var.keyvaults.secret_prefix, "sp")
   }
-  secret_identity_id = data.azurerm_kubernetes_cluster.kubeconfig.key_vault_secrets_provider[0].secret_identity[0].object_id
+  secret_identity_id = try(data.azurerm_kubernetes_cluster.kubeconfig.key_vault_secrets_provider[0].secret_identity[0].object_id, null)
 }


### PR DESCRIPTION
## Description

This plugin only works if key_vault_secrets_provider AKS addon is installed. It should be optional.

## Does this introduce a breaking change

- [ ] YES
- [ x] NO
