### PR TITLE
Update landingzone.tf - changed var.logic_app to local.logic_app

### DIFF
--- a/caf_solution/landingzone.tf
+++ b/caf_solution/landingzone.tf
@@ -38,7 +38,7 @@ module "solution" {
   log_analytics                         = var.log_analytics
   logged_aad_app_objectId               = var.logged_aad_app_objectId
   logged_user_objectId                  = var.logged_user_objectId
-  logic_app                             = var.logic_app
+  logic_app                             = local.logic_app
   managed_identities                    = var.managed_identities
   messaging                             = local.messaging
   networking                            = local.networking


### PR DESCRIPTION
# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [x ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description
The landingzone.tf file in caf_solution is incorrectly using var.logic_app when it should be using local.logic_app , and this causes only resource groups to be created when following https://github.com/aztfmod/terraform-azurerm-caf/blob/int-5.7.0/examples/logic_app/104-logic_app_action_custom/configuration.tfvars example

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [x ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
