### PR TITLE
Add lb_backend_address_pool to remote

### DIFF
--- a/caf_solution/local.remote.tf
+++ b/caf_solution/local.remote.tf
@@ -128,6 +128,9 @@ locals {
     lb = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].lb, {}))
     }
+    lb_backend_address_pool = {
+      for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].lb_backend_address_pool, {}))
+    }
     logic_app_integration_account = {
       for key, value in try(var.landingzone.tfstates, {}) : key => merge(try(data.terraform_remote_state.remote[key].outputs.objects[key].logic_app_integration_account, {}))
     }


### PR DESCRIPTION
## Description

Added lb_backend_address_pool to local.remote.tf to make possible to create a network_interface_backend_address_pool_association from another LZ.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Testing

<!-- Instructions for testing and validation of your code -->

Create a Load Balancer with backendpools and then in another LZ create a network_interface_backend_address_pool_association and refer with a lz_key to the backendpools.

Without this change it was not possible to refer from another LZ to the LB backendpool. 


