### PR TITLE
Update get_tfstate_content.yaml --> set exported variables fix

### DIFF
--- a/templates/ansible/get_tfstate_content.yaml
+++ b/templates/ansible/get_tfstate_content.yaml
@@ -105,9 +105,9 @@
     "{{exported_variable_name}}": "{{ lookup('vars', exported_variable_name, default={}) | combine({item.0: item.1}, recursive=True )) }}"
   with_together:
     - ["{{env}}"]
-    - ["{{jsondata | default({}) | json_query(path)}}"]
+    - ["{{jsondata | default({}) | json_query(path) if resource_key is defined else omit}}"]
   vars:
-    path: 'outputs.objects.value.{{tfstate_key_name}}.{{resource_type}}.{{resource_key}}'
+    path: "outputs.objects.value.{{tfstate_key_name}}.{{resource_type}}{{'.' + resource_key if resource_key is defined else ''}}"
 
 - name: "[{{resources[tfstate].relative_destination_folder}}] cleanup"
   when:


### PR DESCRIPTION
When ressource_key is not defined it tries to set path value even if resource_key must be defined in the when condition because the when condition does not have effect here

# [Issue-id](https://github.com/Azure/caf-terraform-landingzones/issues/ISSUE-ID-GOES-HERE)

## PR Checklist

---

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Description

<!-- Concise description of the problem and the solution or the feature being added -->

## Does this introduce a breaking change

- [ ] YES
- [X] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Instructions for testing and validation of your code -->
